### PR TITLE
feat: membership 회원 조회

### DIFF
--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/ReadMembershipController.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/ReadMembershipController.java
@@ -1,0 +1,40 @@
+package com.yun.membership.adapter.in.web;
+
+import com.yun.membership.adapter.in.web.model.request.ReadMembershipRequest;
+import com.yun.membership.application.port.in.ReadMembershipUseCase;
+import com.yun.membership.domain.Membership;
+import common.WebAdapter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/membership")
+public class ReadMembershipController {
+
+    private final ReadMembershipUseCase readMembershipUseCase;
+
+    @GetMapping("")
+    public ResponseEntity findAllRegisterMember(@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.ASC) Pageable pageable) {
+        Page<Membership> allMembershipUser = readMembershipUseCase.getAllMembershipUser(pageable);
+        return ResponseEntity
+                .ok()
+                .body(allMembershipUser);
+    }
+
+    @GetMapping("/{membershipId}")
+    public ResponseEntity findByMembershipId(@PathVariable("membershipId") ReadMembershipRequest request) {
+        Membership membership = readMembershipUseCase.getMembershipsByMemberId(request.toCommand());
+        return ResponseEntity
+                .ok()
+                .body(membership);
+    }
+}

--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/model/request/ReadMembershipRequest.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/model/request/ReadMembershipRequest.java
@@ -1,0 +1,11 @@
+package com.yun.membership.adapter.in.web.model.request;
+
+import com.yun.membership.application.port.in.ReadMembershipCommand;
+
+public record ReadMembershipRequest(
+   String membershipId
+) {
+    public ReadMembershipCommand toCommand() {
+        return ReadMembershipCommand.of(membershipId);
+    }
+}

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipPersistenceAdapter.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipPersistenceAdapter.java
@@ -1,13 +1,17 @@
 package com.yun.membership.adapter.out.persistence;
 
+import com.yun.membership.application.port.out.ReadMembershipPort;
 import com.yun.membership.application.port.out.RegisterMembershipPort;
 import com.yun.membership.domain.Membership;
 import common.PersistenceAdapter;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class MembershipPersistenceAdapter implements RegisterMembershipPort {
+public class MembershipPersistenceAdapter implements RegisterMembershipPort, ReadMembershipPort {
     private final MembershipJpaRepository membershipJpaRepository;
     @Override
     public MembershipEntity createdMembership(Membership membership) {
@@ -18,5 +22,18 @@ public class MembershipPersistenceAdapter implements RegisterMembershipPort {
                 membership.isValid(),
                 membership.isCorp()
         ));
+    }
+
+    @Override
+    public MembershipEntity findByMembershipId(Membership.MembershipId membershipId) {
+        return membershipJpaRepository.findById(Long.valueOf(membershipId.getId()))
+                .orElseThrow(() -> {
+                    throw new EntityNotFoundException("회원을 찾을 수 없습니다");
+                });
+    }
+
+    @Override
+    public Page<MembershipEntity> findAllMembership(Pageable pageable) {
+        return membershipJpaRepository.findAll(pageable);
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/application/port/in/ReadMembershipCommand.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/in/ReadMembershipCommand.java
@@ -1,0 +1,29 @@
+package com.yun.membership.application.port.in;
+
+import com.yun.membership.adapter.in.web.model.request.ReadMembershipRequest;
+import com.yun.membership.domain.Membership;
+import common.SelfValidating;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class ReadMembershipCommand extends SelfValidating<ReadMembershipRequest> {
+    @NotNull
+    @NotBlank
+    private final String membershipId;
+
+    private ReadMembershipCommand(String membershipId) {
+        this.membershipId = membershipId;
+    }
+
+    public static ReadMembershipCommand of(String membershipId) {
+        return new ReadMembershipCommand(membershipId);
+    }
+
+    public Membership.MembershipId toMembershipId() {
+        return new Membership.MembershipId(membershipId);
+    }
+}

--- a/membership-service/src/main/java/com/yun/membership/application/port/in/ReadMembershipUseCase.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/in/ReadMembershipUseCase.java
@@ -1,0 +1,10 @@
+package com.yun.membership.application.port.in;
+
+import com.yun.membership.domain.Membership;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReadMembershipUseCase {
+    Page<Membership> getAllMembershipUser(Pageable pageable);
+    Membership getMembershipsByMemberId(ReadMembershipCommand readMembershipCommand);
+}

--- a/membership-service/src/main/java/com/yun/membership/application/port/out/ReadMembershipPort.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/out/ReadMembershipPort.java
@@ -1,0 +1,11 @@
+package com.yun.membership.application.port.out;
+
+import com.yun.membership.adapter.out.persistence.MembershipEntity;
+import com.yun.membership.domain.Membership;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReadMembershipPort {
+    MembershipEntity findByMembershipId(Membership.MembershipId membershipId);
+    Page<MembershipEntity> findAllMembership(Pageable pageable);
+}

--- a/membership-service/src/main/java/com/yun/membership/application/service/ReadMembershipService.java
+++ b/membership-service/src/main/java/com/yun/membership/application/service/ReadMembershipService.java
@@ -1,0 +1,35 @@
+package com.yun.membership.application.service;
+
+import com.yun.membership.adapter.out.persistence.MembershipEntity;
+import com.yun.membership.adapter.out.persistence.MembershipMapper;
+import com.yun.membership.application.port.in.ReadMembershipCommand;
+import com.yun.membership.application.port.in.ReadMembershipUseCase;
+import com.yun.membership.application.port.out.ReadMembershipPort;
+import com.yun.membership.domain.Membership;
+import common.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadMembershipService implements ReadMembershipUseCase {
+
+    private final ReadMembershipPort readMembershipPort;
+    private final MembershipMapper mapper;
+    @Override
+    public Page<Membership> getAllMembershipUser(Pageable pageable) {
+        return readMembershipPort.findAllMembership(pageable)
+                .map(membershipEntity -> mapper.mapToDomainEntity(membershipEntity));
+    }
+
+    @Override
+    public Membership getMembershipsByMemberId(ReadMembershipCommand membershipIdCommand) {
+        MembershipEntity byMembershipId = readMembershipPort.findByMembershipId(membershipIdCommand.toMembershipId());
+        return mapper.mapToDomainEntity(byMembershipId);
+    }
+}


### PR DESCRIPTION
: 조회의 경우 DB를 한개로 사용하기 때문에 하나의 adapter를 사용하고 port를 Read, command로 구분하여 구현받도록 개발하였다
- 전체 조회(페이징 처리)
- 특정 회원 조회

#6