### PR TITLE
feat: 페이 머니 충전/감액 구현

### DIFF
--- a/money-service/src/main/java/com/yun/money/adapter/in/web/AdjustMoneyController.java
+++ b/money-service/src/main/java/com/yun/money/adapter/in/web/AdjustMoneyController.java
@@ -1,0 +1,36 @@
+package com.yun.money.adapter.in.web;
+
+import com.yun.common.WebAdapter;
+import com.yun.money.adapter.in.web.model.DecreaseMoneyAmountRequest;
+import com.yun.money.adapter.in.web.model.IncreaseMoneyAmountRequest;
+import com.yun.money.application.port.in.AdjustMoneyUseCase;
+import com.yun.money.domain.PayWalletMoney;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/money")
+public class AdjustMoneyController {
+
+    private final AdjustMoneyUseCase adjustMoneyUseCase;
+
+    @PostMapping("/increase")
+    public ResponseEntity increaseMoneyAmount(@RequestBody IncreaseMoneyAmountRequest increaseMoneyAmountRequest) {
+        PayWalletMoney payWalletMoney = adjustMoneyUseCase.increaseMoneyAmountRequest(increaseMoneyAmountRequest.toCommand());
+        return ResponseEntity.ok().body(payWalletMoney);
+    }
+
+    @PostMapping("/decrease")
+    public ResponseEntity decreaseMoneyAmount(@RequestBody DecreaseMoneyAmountRequest decreaseMoneyAmountRequest) {
+        PayWalletMoney payWalletMoney = adjustMoneyUseCase.decreaseMoneyAmountRequest(decreaseMoneyAmountRequest.toCommand());
+        return ResponseEntity.ok().body(payWalletMoney);
+    }
+}

--- a/money-service/src/main/java/com/yun/money/adapter/in/web/model/DecreaseMoneyAmountRequest.java
+++ b/money-service/src/main/java/com/yun/money/adapter/in/web/model/DecreaseMoneyAmountRequest.java
@@ -1,0 +1,15 @@
+package com.yun.money.adapter.in.web.model;
+
+import com.yun.money.application.port.in.DecreaseMoneyAmountCommand;
+
+public record DecreaseMoneyAmountRequest(
+        String moneyChangingRequestId,
+        String targetMembershipId,
+        String bankAccountNumber,
+        Integer requestAdjustAmount
+) {
+    public DecreaseMoneyAmountCommand toCommand() {
+        return DecreaseMoneyAmountCommand.of(
+                moneyChangingRequestId, targetMembershipId, bankAccountNumber, requestAdjustAmount);
+    }
+}

--- a/money-service/src/main/java/com/yun/money/adapter/in/web/model/IncreaseMoneyAmountRequest.java
+++ b/money-service/src/main/java/com/yun/money/adapter/in/web/model/IncreaseMoneyAmountRequest.java
@@ -1,0 +1,18 @@
+package com.yun.money.adapter.in.web.model;
+
+import com.yun.money.application.port.in.IncreaseMoneyAmountCommand;
+
+public record IncreaseMoneyAmountRequest(
+        String moneyChangingRequestId,
+        String targetMembershipId,
+        String bankAccountNumber,
+        Integer requestAdjustAmount
+) {
+    public IncreaseMoneyAmountCommand toCommand() {
+        return IncreaseMoneyAmountCommand.of(
+                moneyChangingRequestId,
+                targetMembershipId,
+                requestAdjustAmount,
+                bankAccountNumber);
+    }
+}

--- a/money-service/src/main/java/com/yun/money/adapter/in/web/model/MoneyChangingResultDetail.java
+++ b/money-service/src/main/java/com/yun/money/adapter/in/web/model/MoneyChangingResultDetail.java
@@ -1,0 +1,9 @@
+package com.yun.money.adapter.in.web.model;
+
+public record MoneyChangingResultDetail(
+        String moneyChangingRequestId,
+        MoneyChangingType moneyChangingType,
+        MoneyChangingResultStatus moneyChangingResultStatus,
+        int amount
+) {
+}

--- a/money-service/src/main/java/com/yun/money/adapter/in/web/model/MoneyChangingResultStatus.java
+++ b/money-service/src/main/java/com/yun/money/adapter/in/web/model/MoneyChangingResultStatus.java
@@ -1,0 +1,10 @@
+package com.yun.money.adapter.in.web.model;
+
+public enum MoneyChangingResultStatus {
+    SUCCEEDED,
+    PENDING,
+    FAILED,
+    FAILED_NOT_ENOUGH_MONEY, //잔액 부족
+    FAILED_NOT_EXIST_MEMBERSHIP, //멤버십 없음
+    FAILED_NOT_EXIST_MONEY_CHANGING_REQUEST //머니 변액 요청 없음
+}

--- a/money-service/src/main/java/com/yun/money/adapter/in/web/model/MoneyChangingType.java
+++ b/money-service/src/main/java/com/yun/money/adapter/in/web/model/MoneyChangingType.java
@@ -1,0 +1,6 @@
+package com.yun.money.adapter.in.web.model;
+
+public enum MoneyChangingType {
+    INCREASING,
+    DECREASING
+}

--- a/money-service/src/main/java/com/yun/money/adapter/out/persistence/AdjustMoneyAmountAdapter.java
+++ b/money-service/src/main/java/com/yun/money/adapter/out/persistence/AdjustMoneyAmountAdapter.java
@@ -1,0 +1,35 @@
+package com.yun.money.adapter.out.persistence;
+
+import com.yun.common.PersistenceAdapter;
+import com.yun.money.adapter.out.persistence.factory.PayWalletMoneyFactory;
+import com.yun.money.application.port.out.DecreaseMoneyAmountPort;
+import com.yun.money.application.port.out.IncreaseMoneyAmountPort;
+import com.yun.money.domain.PayWalletMoney;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class AdjustMoneyAmountAdapter implements IncreaseMoneyAmountPort, DecreaseMoneyAmountPort {
+
+    private final PayWalletMoneyJpaRepository payWalletMoneyJpaRepository;
+    private final PayWalletMoneyMapper mapper;
+
+    @Override
+    public PayWalletMoney decreaseMoneyAmount(PayWalletMoney payWalletMoney) {
+        PayWalletMoneyEntity payWalletMoneyEntity = payWalletMoneyJpaRepository.save(PayWalletMoneyFactory.toEntity(payWalletMoney));
+        return mapper.mapToDomainWalletMoney(payWalletMoneyEntity);
+    }
+
+    @Override
+    public Integer moneyTotalAmount(String bankAccountNumber) {
+        return payWalletMoneyJpaRepository
+                .moneyTotalAmount(bankAccountNumber);
+    }
+
+    @Override
+    public PayWalletMoney increaseMoneyAmount(PayWalletMoney payWalletMoney) {
+        PayWalletMoneyEntity payWalletMoneyEntity
+                = payWalletMoneyJpaRepository.save(PayWalletMoneyFactory.toEntity(payWalletMoney));
+        return mapper.mapToDomainWalletMoney(payWalletMoneyEntity);
+    }
+}

--- a/money-service/src/main/java/com/yun/money/adapter/out/persistence/PayWalletMoneyEntity.java
+++ b/money-service/src/main/java/com/yun/money/adapter/out/persistence/PayWalletMoneyEntity.java
@@ -1,0 +1,67 @@
+package com.yun.money.adapter.out.persistence;
+
+import com.yun.money.adapter.in.web.model.MoneyChangingResultStatus;
+import com.yun.money.adapter.in.web.model.MoneyChangingType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Objects;
+
+@ToString
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "t_pay_wallet_money")
+public class PayWalletMoneyEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pay_wallet_money_id")
+    private Long id;
+    @Column(name = "money_request_id")
+    private String moneyRequestId;
+    @Column(name = "target_membership_id")
+    private String targetMembershipId;
+    @Column(name = "bank_account_number")
+    private String bankAccountNumber;
+    @Column(name = "adjust_amount")
+    private Integer adjustAmount;
+    @Column(name = "linked_status_valid")
+    private boolean linkedStatusIsValid;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "money_change_type")
+    private MoneyChangingType moneyChangType;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "money_changed_result_status")
+    private MoneyChangingResultStatus moneyChangingResultStatus;
+
+    @Builder
+    public PayWalletMoneyEntity(String moneyRequestId,
+                                String targetMembershipId,
+                                String bankAccountNumber,
+                                Integer adjustAmount,
+                                boolean linkedStatusIsValid,
+                                MoneyChangingType moneyChangType,
+                                MoneyChangingResultStatus moneyChangingResultStatus) {
+        this.moneyRequestId = moneyRequestId;
+        this.targetMembershipId = targetMembershipId;
+        this.bankAccountNumber = bankAccountNumber;
+        this.adjustAmount = adjustAmount;
+        this.linkedStatusIsValid = linkedStatusIsValid;
+        this.moneyChangType = moneyChangType;
+        this.moneyChangingResultStatus = moneyChangingResultStatus;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PayWalletMoneyEntity that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+}

--- a/money-service/src/main/java/com/yun/money/adapter/out/persistence/PayWalletMoneyJpaRepository.java
+++ b/money-service/src/main/java/com/yun/money/adapter/out/persistence/PayWalletMoneyJpaRepository.java
@@ -1,0 +1,10 @@
+package com.yun.money.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PayWalletMoneyJpaRepository extends JpaRepository<PayWalletMoneyEntity, Long> {
+    @Query(value = "select sum(pay.adjustAmount) from PayWalletMoneyEntity pay where pay.bankAccountNumber = :bankAccountNumber and pay.moneyChangingResultStatus = 'SUCCEEDED'")
+    Integer moneyTotalAmount(@Param("bankAccountNumber") String bankAccountNumber);
+}

--- a/money-service/src/main/java/com/yun/money/adapter/out/persistence/PayWalletMoneyMapper.java
+++ b/money-service/src/main/java/com/yun/money/adapter/out/persistence/PayWalletMoneyMapper.java
@@ -1,0 +1,21 @@
+package com.yun.money.adapter.out.persistence;
+
+import com.yun.money.domain.PayWalletMoney;
+import org.springframework.stereotype.Component;
+
+import static com.yun.money.domain.PayWalletMoney.*;
+
+@Component
+public class PayWalletMoneyMapper {
+    public PayWalletMoney mapToDomainWalletMoney(PayWalletMoneyEntity entity) {
+        return generatedPayWalletChangeMoney(
+                new MoneyChangingRequestId(entity.getMoneyRequestId()),
+                new TargetMembershipId(entity.getTargetMembershipId()),
+                new ChangingTypes(entity.getMoneyChangType()),
+                new BankAccountNumber(entity.getBankAccountNumber()),
+                new RequestAdjustAmount(entity.getAdjustAmount()),
+                new ChangedMoneyStatus(entity.getMoneyChangingResultStatus()),
+                new LinkedStatusIsValid(entity.isLinkedStatusIsValid())
+        );
+    }
+}

--- a/money-service/src/main/java/com/yun/money/adapter/out/persistence/factory/PayWalletMoneyFactory.java
+++ b/money-service/src/main/java/com/yun/money/adapter/out/persistence/factory/PayWalletMoneyFactory.java
@@ -1,0 +1,18 @@
+package com.yun.money.adapter.out.persistence.factory;
+
+import com.yun.money.adapter.out.persistence.PayWalletMoneyEntity;
+import com.yun.money.domain.PayWalletMoney;
+
+public class PayWalletMoneyFactory {
+    public static PayWalletMoneyEntity toEntity(PayWalletMoney payWalletMoney) {
+        return PayWalletMoneyEntity.builder()
+                .moneyRequestId(payWalletMoney.getChangeRequestId().getRequestId().toString())
+                .targetMembershipId(payWalletMoney.getTargetMembershipId())
+                .bankAccountNumber(payWalletMoney.getBankAccountNumber())
+                .adjustAmount(payWalletMoney.getAdjustAmount())
+                .linkedStatusIsValid(payWalletMoney.isLinkedStatusIsValid())
+                .moneyChangType(payWalletMoney.getMoneyChangingType())
+                .moneyChangingResultStatus(payWalletMoney.getMoneyChangingResultStatus())
+                .build();
+    }
+}

--- a/money-service/src/main/java/com/yun/money/application/port/in/AdjustMoneyUseCase.java
+++ b/money-service/src/main/java/com/yun/money/application/port/in/AdjustMoneyUseCase.java
@@ -1,0 +1,8 @@
+package com.yun.money.application.port.in;
+
+import com.yun.money.domain.PayWalletMoney;
+
+public interface AdjustMoneyUseCase {
+    PayWalletMoney increaseMoneyAmountRequest(IncreaseMoneyAmountCommand command);
+    PayWalletMoney decreaseMoneyAmountRequest(DecreaseMoneyAmountCommand command);
+}

--- a/money-service/src/main/java/com/yun/money/application/port/in/DecreaseMoneyAmountCommand.java
+++ b/money-service/src/main/java/com/yun/money/application/port/in/DecreaseMoneyAmountCommand.java
@@ -1,0 +1,69 @@
+package com.yun.money.application.port.in;
+
+import com.yun.common.SelfValidating;
+import com.yun.money.adapter.in.web.model.DecreaseMoneyAmountRequest;
+import com.yun.money.adapter.in.web.model.IncreaseMoneyAmountRequest;
+import com.yun.money.adapter.in.web.model.MoneyChangingResultStatus;
+import com.yun.money.adapter.in.web.model.MoneyChangingType;
+import com.yun.money.domain.PayWalletMoney;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import static com.yun.money.domain.PayWalletMoney.*;
+import static com.yun.money.domain.PayWalletMoney.generatedPayWalletChangeMoney;
+
+@Getter
+@EqualsAndHashCode
+public class DecreaseMoneyAmountCommand extends SelfValidating<DecreaseMoneyAmountRequest> {
+
+    @NotNull
+    @NotEmpty
+    private final String moneyChangingRequestId;
+    @NotNull
+    @NotEmpty
+    private final String targetMembershipId;
+    @NotNull
+    @NotEmpty
+    private final String bankAccountNumber;
+    @NotNull
+    @NotEmpty
+    private final Integer requestAdjustAmount;
+    private final MoneyChangingType changingType;
+
+
+    private DecreaseMoneyAmountCommand(String moneyChangingRequestId,
+                                       String targetMembershipId,
+                                       MoneyChangingType moneyChangingType,
+                                       Integer requestAdjustAmount,
+                                       String bankAccountNumber) {
+        this.moneyChangingRequestId = moneyChangingRequestId;
+        this.targetMembershipId = targetMembershipId;
+        this.requestAdjustAmount = requestAdjustAmount;
+        this.changingType = moneyChangingType;
+        this.bankAccountNumber = bankAccountNumber;
+    }
+
+    public static DecreaseMoneyAmountCommand of(String moneyChangingRequestId,
+                                                String targetMembershipId,
+                                                String bankAccountNumber,
+                                                Integer requestAdjustAmount) {
+        return new DecreaseMoneyAmountCommand(moneyChangingRequestId,
+                targetMembershipId,
+                MoneyChangingType.DECREASING,
+                requestAdjustAmount,
+                bankAccountNumber);
+    }
+
+    public PayWalletMoney toPayWalletMoney(MoneyChangingResultStatus moneyChangingResultStatus) {
+        return generatedPayWalletChangeMoney(
+                new MoneyChangingRequestId(moneyChangingRequestId),
+                new TargetMembershipId(targetMembershipId),
+                new ChangingTypes(changingType),
+                new BankAccountNumber(bankAccountNumber),
+                new RequestAdjustAmount(requestAdjustAmount),
+                new ChangedMoneyStatus(moneyChangingResultStatus),
+                new LinkedStatusIsValid(true));
+    }
+}

--- a/money-service/src/main/java/com/yun/money/application/port/in/IncreaseMoneyAmountCommand.java
+++ b/money-service/src/main/java/com/yun/money/application/port/in/IncreaseMoneyAmountCommand.java
@@ -1,0 +1,68 @@
+package com.yun.money.application.port.in;
+
+import com.yun.common.SelfValidating;
+import com.yun.money.adapter.in.web.model.IncreaseMoneyAmountRequest;
+import com.yun.money.adapter.in.web.model.MoneyChangingResultStatus;
+import com.yun.money.adapter.in.web.model.MoneyChangingType;
+import com.yun.money.domain.PayWalletMoney;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import static com.yun.money.domain.PayWalletMoney.*;
+
+@Getter
+@EqualsAndHashCode
+public class IncreaseMoneyAmountCommand extends SelfValidating<IncreaseMoneyAmountRequest> {
+
+    @NotNull
+    @NotEmpty
+    private final String moneyChangingRequestId;
+    @NotNull
+    @NotEmpty
+    private final String targetMembershipId;
+    @NotNull
+    @NotEmpty
+    private final String bankAccountNumber;
+    @NotNull
+    @NotEmpty
+    private final Integer requestAdjustAmount;
+    private final MoneyChangingType changingType;
+
+
+    private IncreaseMoneyAmountCommand(String moneyChangingRequestId,
+                                       String targetMembershipId,
+                                       MoneyChangingType moneyChangingType,
+                                       Integer requestAdjustAmount,
+                                       String bankAccountNumber) {
+        this.moneyChangingRequestId = moneyChangingRequestId;
+        this.targetMembershipId = targetMembershipId;
+        this.requestAdjustAmount = requestAdjustAmount;
+        this.changingType = moneyChangingType;
+        this.bankAccountNumber = bankAccountNumber;
+    }
+
+    public static IncreaseMoneyAmountCommand of(String moneyChangingRequestId,
+                                                String targetMembershipId,
+                                                Integer requestAdjustAmount,
+                                                String bankAccountNumber) {
+        return new IncreaseMoneyAmountCommand(moneyChangingRequestId,
+                targetMembershipId,
+                MoneyChangingType.INCREASING,
+                requestAdjustAmount,
+                bankAccountNumber);
+    }
+
+    public PayWalletMoney toPayWalletMoney(MoneyChangingResultStatus moneyChangingResultStatus) {
+        return generatedPayWalletChangeMoney(
+                new MoneyChangingRequestId(moneyChangingRequestId),
+                new TargetMembershipId(targetMembershipId),
+                new ChangingTypes(changingType),
+                new BankAccountNumber(bankAccountNumber),
+                new RequestAdjustAmount(requestAdjustAmount),
+                new ChangedMoneyStatus(moneyChangingResultStatus),
+                new LinkedStatusIsValid(true)
+        );
+    }
+}

--- a/money-service/src/main/java/com/yun/money/application/port/out/DecreaseMoneyAmountPort.java
+++ b/money-service/src/main/java/com/yun/money/application/port/out/DecreaseMoneyAmountPort.java
@@ -1,0 +1,8 @@
+package com.yun.money.application.port.out;
+
+import com.yun.money.domain.PayWalletMoney;
+
+public interface DecreaseMoneyAmountPort {
+    PayWalletMoney decreaseMoneyAmount(PayWalletMoney payWalletMoney);
+    Integer moneyTotalAmount(String bankAccountNumber);
+}

--- a/money-service/src/main/java/com/yun/money/application/port/out/IncreaseMoneyAmountPort.java
+++ b/money-service/src/main/java/com/yun/money/application/port/out/IncreaseMoneyAmountPort.java
@@ -1,0 +1,7 @@
+package com.yun.money.application.port.out;
+
+import com.yun.money.domain.PayWalletMoney;
+
+public interface IncreaseMoneyAmountPort {
+    PayWalletMoney increaseMoneyAmount(PayWalletMoney payWalletMoney);
+}

--- a/money-service/src/main/java/com/yun/money/application/service/AdjustMoneyAmountService.java
+++ b/money-service/src/main/java/com/yun/money/application/service/AdjustMoneyAmountService.java
@@ -1,0 +1,52 @@
+package com.yun.money.application.service;
+
+import com.yun.common.UseCase;
+import com.yun.money.adapter.in.web.model.MoneyChangingResultStatus;
+import com.yun.money.application.port.in.AdjustMoneyUseCase;
+import com.yun.money.application.port.in.DecreaseMoneyAmountCommand;
+import com.yun.money.application.port.in.IncreaseMoneyAmountCommand;
+import com.yun.money.application.port.out.DecreaseMoneyAmountPort;
+import com.yun.money.application.port.out.IncreaseMoneyAmountPort;
+import com.yun.money.domain.MoneyAmountCalculator;
+import com.yun.money.domain.PayWalletMoney;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class AdjustMoneyAmountService implements AdjustMoneyUseCase {
+
+    private final IncreaseMoneyAmountPort increaseMoneyAmountPort;
+    private final DecreaseMoneyAmountPort decreaseMoneyAmountPort;
+    private final MoneyAmountCalculator moneyAmountCalculator;
+
+    @Override
+    public PayWalletMoney increaseMoneyAmountRequest(IncreaseMoneyAmountCommand command) {
+        //증액(충전)
+        //1. TODO: 멤버십 회원 검증
+        //1-1 고객의 연동된 계좌가 있는지 + 정상여부 체크
+        //1-2 페이 법인 계좌 상태 정상 여부 체크 및 입출금 가능 여부 체크
+        //2. TODO: money 요청 히스토리 저장 (계산하는 검증 로직 필요) (요청 상태로 저장)
+        return increaseMoneyAmountPort.increaseMoneyAmount(command.toPayWalletMoney(MoneyChangingResultStatus.SUCCEEDED));
+        //3. TODO: 펌뱅킹 (고객의 연동된 계좌 -> 법인 계좌)
+        //4. 정상/실패 예외 및 정상 처리
+    }
+
+    @Override
+    public PayWalletMoney decreaseMoneyAmountRequest(DecreaseMoneyAmountCommand command) {
+        //감액(사용)
+        //1. TODO: 멤버십 회원 검증
+        //2. money 금액 확인 (기존 금액 > 요청 금액)
+        //2-1. 기존 금액 합산 쿼리(합산액은 0이하가 될 수 없다)
+        Integer moneyTotalAmount = decreaseMoneyAmountPort.moneyTotalAmount(command.getBankAccountNumber());
+        //2-2. 계산
+        MoneyChangingResultStatus moneyChangingApprovalStatus
+                = moneyAmountCalculator.checkAmountApproval(moneyTotalAmount, command.getRequestAdjustAmount());
+        log.info("moneyTotalAmount:{}", moneyTotalAmount);
+        //3. money 요청 히스토리 저장
+        return decreaseMoneyAmountPort.decreaseMoneyAmount(command.toPayWalletMoney(moneyChangingApprovalStatus));
+    }
+}

--- a/money-service/src/main/java/com/yun/money/domain/MoneyAmountCalculator.java
+++ b/money-service/src/main/java/com/yun/money/domain/MoneyAmountCalculator.java
@@ -1,0 +1,20 @@
+package com.yun.money.domain;
+
+import com.yun.money.adapter.in.web.model.MoneyChangingResultStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MoneyAmountCalculator {
+    //계산하는 로직
+    public MoneyChangingResultStatus checkAmountApproval(Integer moneyTotalAmount, Integer requestAmount) {
+        if (moneyTotalAmount >= requestAmount || moneyTotalAmount == requestAmount) {
+            return MoneyChangingResultStatus.SUCCEEDED;
+        }
+
+        if (moneyTotalAmount < requestAmount || moneyTotalAmount <= 0) {
+            return MoneyChangingResultStatus.FAILED_NOT_ENOUGH_MONEY;
+        }
+
+        return MoneyChangingResultStatus.FAILED;
+    }
+}

--- a/money-service/src/main/java/com/yun/money/domain/PayWalletMoney.java
+++ b/money-service/src/main/java/com/yun/money/domain/PayWalletMoney.java
@@ -1,0 +1,121 @@
+package com.yun.money.domain;
+
+import com.yun.money.adapter.in.web.model.MoneyChangingResultStatus;
+import com.yun.money.adapter.in.web.model.MoneyChangingType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Value;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PayWalletMoney {
+
+    private final String moneyChangingRequestId;
+    // 어떤 고객의 증액/감액 요청을 요청했는지의 멤버 정보
+    private final String targetMembershipId;
+    // 요청에 대한 타입(증액/감액)
+    private final MoneyChangingType moneyChangingType;
+    // 증액 또는 감액에 대한 계좌
+    private final String bankAccountNumber;
+    // 머니 변액 요청에 대한 상태
+    private final boolean linkedStatusIsValid;
+    private final Integer adjustAmount;
+    private final MoneyChangingResultStatus moneyChangingResultStatus;
+    private final ChangeRequestId changeRequestId;
+
+    public static PayWalletMoney generatedPayWalletChangeMoney(
+            MoneyChangingRequestId moneyChangingRequestId,
+            TargetMembershipId targetMembershipId,
+            ChangingTypes moneyChangingType,
+            BankAccountNumber bankAccountNumber,
+            RequestAdjustAmount requestAdjustAmount,
+            ChangedMoneyStatus moneyChangingResultStatus,
+            LinkedStatusIsValid linkedStatusIsValid
+    ) {
+        return new PayWalletMoney(
+                moneyChangingRequestId.moneyChangingRequestId,
+                targetMembershipId.targetMembershipId,
+                moneyChangingType.changingType,
+                bankAccountNumber.bankAccountNumber,
+                linkedStatusIsValid.linkedStatusIsValid,
+                requestAdjustAmount.requestAdjustAmount,
+                moneyChangingResultStatus.changingMoneyStatus,
+                new ChangeRequestId()
+        );
+    }
+
+    @Value
+    public static class MoneyChangingRequestId {
+        String moneyChangingRequestId;
+
+        public MoneyChangingRequestId(String value) {
+            this.moneyChangingRequestId = value;
+        }
+    }
+
+    @Value
+    public static class TargetMembershipId {
+        String targetMembershipId;
+
+        public TargetMembershipId(String value) {
+            this.targetMembershipId = value;
+        }
+    }
+
+    @Value
+    public static class ChangingTypes {
+        MoneyChangingType changingType;
+
+        public ChangingTypes(MoneyChangingType value) {
+            this.changingType = value;
+        }
+    }
+
+    @Value
+    public static class BankAccountNumber {
+        String bankAccountNumber;
+
+        public BankAccountNumber(String value) {
+            this.bankAccountNumber = value;
+        }
+    }
+
+    @Value
+    public static class LinkedStatusIsValid {
+        boolean linkedStatusIsValid;
+
+        public LinkedStatusIsValid(boolean value) {
+            this.linkedStatusIsValid = value;
+        }
+    }
+
+    @Value
+    public static class RequestAdjustAmount {
+        Integer requestAdjustAmount;
+
+        public RequestAdjustAmount(Integer value) {
+            this.requestAdjustAmount = value;
+        }
+    }
+
+    @Value
+    public static class ChangeRequestId {
+        UUID requestId;
+
+        public ChangeRequestId() {
+            this.requestId = UUID.randomUUID();
+        }
+    }
+
+    @Value
+    public static class ChangedMoneyStatus {
+        MoneyChangingResultStatus changingMoneyStatus;
+
+        public ChangedMoneyStatus(MoneyChangingResultStatus value) {
+            this.changingMoneyStatus = value;
+        }
+    }
+}


### PR DESCRIPTION
- 페이 지갑 역할을 하는 money 충전 기능 (연동된 회원의 계좌에서) 충전시 머니 증액과 법인 계좌 증액
  - 고객 정보 정상 여부 
  - 고객의 연동된 계좌 정상 여부 및 잔액 확인
  - 법인 계좌 상태 확인
  - 증액 요청 히스토리 기록, 요청 상태로 저장
  - 펌뱅킹 (API) 요청 후 회원계좌 -> 법인 계좌로 이체
  - 회원의 머니 증액
  - 결과 정상/실패 여부 확인 후 반환
- 감액의 경우 머니와 요청 금액 비교 후 감액
  - 고객 정보 정상 여부
  - 회원 머니 금액과 요청 금액 계산 후 가능 여부 체크
  - 외부 회원에게 이체 (송금) (법인 계좌 -> 외부 계좌 송금)
  - 회원 머니 감액
  - 결과 반환

#30