### PR TITLE
feat: membership exception global 처리

### DIFF
--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/model/MembershipResult.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/model/MembershipResult.java
@@ -1,0 +1,21 @@
+package com.yun.membership.adapter.in.web.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MembershipResult<T> {
+    private String status;
+    private T result;
+
+    public static <T> MembershipResult<T> error(T result) {
+        return new MembershipResult("ERROR", result);
+    }
+
+    public static <T> MembershipResult<T> success(T result) {
+        return new MembershipResult("SUCCESS", result);
+    }
+}

--- a/membership-service/src/main/java/com/yun/membership/exception/ErrorResult.java
+++ b/membership-service/src/main/java/com/yun/membership/exception/ErrorResult.java
@@ -1,0 +1,14 @@
+package com.yun.membership.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResult<T> {
+    private T errorCode;
+    private String message;
+}

--- a/membership-service/src/main/java/com/yun/membership/exception/MembershipErrorCode.java
+++ b/membership-service/src/main/java/com/yun/membership/exception/MembershipErrorCode.java
@@ -1,0 +1,17 @@
+package com.yun.membership.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MembershipErrorCode {
+    USER_ALREADY_EXIST_ACCOUNT      ("UA0001", HttpStatus.CONFLICT, "이미 가입된 사용자 입니다"),
+    USER_NOTFOUND_ACCOUNT           ("UA0002", HttpStatus.NOT_FOUND, "존재하지 않는 사용자 입니다"),
+    INVALID_USER_ID_PASSWORD        ("UA0003", HttpStatus.FORBIDDEN, "아이디 또는 비밀번호가 일치하지 않습니다. 회원정보를 확인해주세요");
+
+    private String errorCode;
+    private HttpStatus status;
+    private String message;
+}

--- a/membership-service/src/main/java/com/yun/membership/exception/MembershipGlobalExceptionHandler.java
+++ b/membership-service/src/main/java/com/yun/membership/exception/MembershipGlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.yun.membership.exception;
+
+import com.yun.membership.adapter.in.web.model.MembershipResult;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class MembershipGlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<?> runtimeExceptionHandler(MembershipModuleException e) {
+        return ResponseEntity
+                .status(e.getMembershipErrorCode().getStatus())
+                .body(MembershipResult.error(e.getMessage()));
+    }
+
+    @ExceptionHandler(MembershipModuleException.class)
+    public ResponseEntity<?> AwesomeAppExceptionHandler(MembershipModuleException appEx) {
+        ErrorResult errorResult = new ErrorResult(appEx.getMembershipErrorCode(), appEx.getMessage());
+        return ResponseEntity
+                .status(appEx.getMembershipErrorCode().getStatus())
+                .body(MembershipResult.error(errorResult));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex,
+                                                                         HttpHeaders headers,
+                                                                         HttpStatusCode status,
+                                                                         final WebRequest request)
+    {
+        logger.debug("HttpRequestMethodNotSupported : {} ", ex);
+        ErrorResult errorResult = new ErrorResult(ex.getStatusCode(), ex.getMessage());
+        return ResponseEntity
+                .status(status)
+                .headers(headers)
+                .body(MembershipResult.error(errorResult));
+    }
+}

--- a/membership-service/src/main/java/com/yun/membership/exception/MembershipModuleException.java
+++ b/membership-service/src/main/java/com/yun/membership/exception/MembershipModuleException.java
@@ -1,0 +1,11 @@
+package com.yun.membership.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MembershipModuleException extends RuntimeException{
+    private MembershipErrorCode membershipErrorCode;
+    private String message;
+}


### PR DESCRIPTION
- MembershipModuleException.class를 통해서 membership에서 발생하는 exception을 전부 처리
- MembershipResult를 통해서 반환 타입 일관성 유지
- error code enum관리
- RestControllerAdvice exception 전역 처리

This closes #50