### PR TITLE
Feature/#51 membership service refactoring

### DIFF
--- a/logging-service/src/main/java/com/yun/loggingservice/kafka/LoggingConsumer.java
+++ b/logging-service/src/main/java/com/yun/loggingservice/kafka/LoggingConsumer.java
@@ -16,7 +16,7 @@ import java.util.Properties;
 public class LoggingConsumer {
 
     private KafkaConsumer<String, String> consumer;
-    private String topicName;
+    private final String topicName;
 
     public LoggingConsumer(@Value("${kafka.clusters.bootstrapservers}") String bootstrapServers,
                            @Value("${logging.topic}") String topicName) {

--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/ModifyMembershipController.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/ModifyMembershipController.java
@@ -1,6 +1,7 @@
 package com.yun.membership.adapter.in.web;
 
 import com.yun.common.WebAdapter;
+import com.yun.membership.adapter.in.web.model.MembershipResult;
 import com.yun.membership.adapter.in.web.model.request.ModifyMembershipRequest;
 import com.yun.membership.application.port.in.ModifyMembershipUseCase;
 import com.yun.membership.domain.Membership;
@@ -15,11 +16,12 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/membership")
 public class ModifyMembershipController {
+
     private final ModifyMembershipUseCase modifyMembershipUseCase;
 
     @PutMapping("/modify")
-    public ResponseEntity modifyMembershipById(@RequestBody ModifyMembershipRequest modifyMembershipRequest) {
+    public ResponseEntity<MembershipResult> modifyMembershipById(@RequestBody ModifyMembershipRequest modifyMembershipRequest) {
         Membership membership = modifyMembershipUseCase.modifyMembershipInfo(modifyMembershipRequest.toCommand());
-        return ResponseEntity.ok().body(membership);
+        return ResponseEntity.ok().body(MembershipResult.success(membership));
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/ReadMembershipController.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/ReadMembershipController.java
@@ -1,6 +1,7 @@
 package com.yun.membership.adapter.in.web;
 
 import com.yun.common.WebAdapter;
+import com.yun.membership.adapter.in.web.model.MembershipResult;
 import com.yun.membership.adapter.in.web.model.request.ReadMembershipRequest;
 import com.yun.membership.application.port.in.ReadMembershipUseCase;
 import com.yun.membership.domain.Membership;
@@ -26,16 +27,12 @@ public class ReadMembershipController {
     @GetMapping("")
     public ResponseEntity findAllRegisterMember(@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.ASC) Pageable pageable) {
         Page<Membership> allMembershipUser = readMembershipUseCase.getAllMembershipUser(pageable);
-        return ResponseEntity
-                .ok()
-                .body(allMembershipUser);
+        return ResponseEntity.ok().body(allMembershipUser);
     }
 
     @GetMapping("/{membershipId}")
-    public ResponseEntity findByMembershipId(@PathVariable("membershipId") ReadMembershipRequest request) {
+    public ResponseEntity<MembershipResult> findByMembershipId(@PathVariable("membershipId") ReadMembershipRequest request) {
         Membership membership = readMembershipUseCase.getMembershipsByMemberId(request.toCommand());
-        return ResponseEntity
-                .ok()
-                .body(membership);
+        return ResponseEntity.ok().body(MembershipResult.success(membership));
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/RegisterMembershipController.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/RegisterMembershipController.java
@@ -1,8 +1,10 @@
 package com.yun.membership.adapter.in.web;
 
 import com.yun.common.WebAdapter;
+import com.yun.membership.adapter.in.web.model.MembershipResult;
 import com.yun.membership.adapter.in.web.model.request.RegisterMembershipRequest;
 import com.yun.membership.application.port.in.RegisterMembershipUseCase;
+import com.yun.membership.domain.Membership;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -21,10 +23,9 @@ public class RegisterMembershipController {
     private final RegisterMembershipUseCase registerMembershipUseCase;
 
     @PostMapping("/register")
-    public ResponseEntity registerMemberShip(@RequestBody RegisterMembershipRequest registerMembershipRequest) {
+    public ResponseEntity<MembershipResult> registerMemberShip(@RequestBody RegisterMembershipRequest registerMembershipRequest) {
         log.info("membership register request: {}", registerMembershipRequest);
-        return ResponseEntity
-                .ok()
-                .body(registerMembershipUseCase.registerMembership(registerMembershipRequest.toCommand()));
+        Membership membership = registerMembershipUseCase.registerMembership(registerMembershipRequest.toCommand());
+        return ResponseEntity.ok().body(MembershipResult.success(membership));
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/model/request/ModifyMembershipRequest.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/model/request/ModifyMembershipRequest.java
@@ -6,16 +6,14 @@ public record ModifyMembershipRequest(
         String membershipId,
         String name,
         String email,
-        String address,
-        boolean isCorp
+        String address
 ) {
     public ModifyMembershipCommand toCommand() {
         return ModifyMembershipCommand.of(
                 membershipId,
                 name,
                 email,
-                address,
-                isCorp
+                address
         );
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/model/request/ModifyMembershipRequest.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/model/request/ModifyMembershipRequest.java
@@ -2,17 +2,17 @@ package com.yun.membership.adapter.in.web.model.request;
 
 import com.yun.membership.application.port.in.ModifyMembershipCommand;
 
+/**
+ * 회원 정보 수정
+ * email, password 수정의 경우 본인 인증 및 검증이 필요하므로 API 분리
+ */
 public record ModifyMembershipRequest(
         String membershipId,
-        String name,
-        String email,
         String address
 ) {
     public ModifyMembershipCommand toCommand() {
         return ModifyMembershipCommand.of(
                 membershipId,
-                name,
-                email,
                 address
         );
     }

--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/model/request/RegisterMembershipRequest.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/model/request/RegisterMembershipRequest.java
@@ -3,18 +3,20 @@ package com.yun.membership.adapter.in.web.model.request;
 import com.yun.membership.application.port.in.RegisterMembershipCommand;
 
 public record RegisterMembershipRequest(
+        String membershipId,
+        String membershipPw,
+        String membershipEmail,
         String name,
-        String address,
-        String email,
-        boolean isCorp
+        String address
 ) {
     public RegisterMembershipCommand toCommand() {
         return RegisterMembershipCommand.of(
+                this.membershipId,
+                this.membershipPw,
+                this.membershipEmail,
                 this.name,
-                this.email,
                 this.address,
-                true,
-                this.isCorp
+                false
         );
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipEntity.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipEntity.java
@@ -2,7 +2,10 @@ package com.yun.membership.adapter.out.persistence;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @ToString
@@ -10,25 +13,46 @@ import java.util.Objects;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "t_membership")
+@Table(name = "t_membership",
+        indexes = {
+                @Index(columnList = "membershipId"),
+                @Index(columnList = "membershipEmail")
+        })
 public class MembershipEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "membership_id")
-    private Long id;
-    @Column(name = "name")
+    @Column(name = "membership_id", length = 50)
+    private String membershipId;
+    @Column(name = "membership_pw", length = 50, nullable = false)
+    private String membershipPw;
+    @Column(name = "membership_email", length = 100, nullable = false)
+    private String membershipEmail;
+    @Column(name = "name", length = 50, nullable = false)
     private String name;
-    @Column(name = "address")
+    @Column(name = "address", length = 150)
     private String address;
-    @Column(name = "email")
-    private String email;
     @Column(name = "is_valid")
     private boolean isValid;
-    @Column(name = "is_corp")
-    private boolean isCorp;
 
-    public static MembershipEntity of(String name, String address, String email, boolean isValid, boolean isCorp) {
-        return new MembershipEntity(null, name, address, email, isValid, isCorp);
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+    @CreatedDate
+    @Column(name = "deleted_at", updatable = false)
+    private LocalDateTime deletedAt;
+
+    public static MembershipEntity of(String membershipId,
+                            String membershipPw,
+                            String membershipEmail,
+                            String name,
+                            String address,
+                            boolean isValid,
+                            LocalDateTime createdAt,
+                            LocalDateTime modifiedAt,
+                            LocalDateTime deletedAt) {
+        return new MembershipEntity(membershipId, membershipPw, membershipEmail, name, address, isValid, createdAt, modifiedAt, deletedAt);
     }
 
     public void updateMembershipInfo(String name, String address) {
@@ -44,11 +68,11 @@ public class MembershipEntity {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof MembershipEntity that)) return false;
-        return Objects.equals(id, that.id);
+        return Objects.equals(membershipId, that.membershipId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(membershipId);
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipEntity.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipEntity.java
@@ -55,9 +55,9 @@ public class MembershipEntity {
         return new MembershipEntity(membershipId, membershipPw, membershipEmail, name, address, isValid, createdAt, modifiedAt, deletedAt);
     }
 
-    public void updateMembershipInfo(String name, String address) {
-        if (name == null || !name.isBlank()) {
-            this.name = name;
+    public void updateMembershipInfo(String membershipId, String address) {
+        if (membershipId == null || !membershipId.isBlank()) {
+            this.membershipId = membershipId;
         }
         if (address == null || !address.isBlank()) {
             this.address = address;

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipJpaRepository.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipJpaRepository.java
@@ -2,5 +2,5 @@ package com.yun.membership.adapter.out.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MembershipJpaRepository extends JpaRepository<MembershipEntity, Long> {
+public interface MembershipJpaRepository extends JpaRepository<MembershipEntity, String> {
 }

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipMapper.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipMapper.java
@@ -26,7 +26,7 @@ public class MembershipMapper {
                         membership.getMembershipEmail(),
                         membership.getName(),
                         membership.getAddress(),
-                        membership.isValid(),
+                        true,
                         membership.getCreatedAt(),
                         membership.getModifiedAt(),
                         null

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipMapper.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipMapper.java
@@ -3,16 +3,34 @@ package com.yun.membership.adapter.out.persistence;
 import com.yun.membership.domain.Membership;
 import org.springframework.stereotype.Component;
 
+import static com.yun.membership.domain.Membership.*;
+
 @Component
 public class MembershipMapper {
-    public Membership mapToDomainEntity(MembershipEntity membershipEntity) {
-        return Membership.generateMember(
-                new Membership.MembershipId(membershipEntity.getId()+""),
-                new Membership.MembershipName(membershipEntity.getName()),
-                new Membership.MembershipEmail(membershipEntity.getEmail()),
-                new Membership.MembershipAddress(membershipEntity.getAddress()),
-                new Membership.MembershipIsValid(membershipEntity.isValid()),
-                new Membership.MembershipIsCorp(membershipEntity.isCorp())
+    public Membership mapToMembership(MembershipEntity membershipEntity) {
+        return generateOutMember(
+                new MembershipId(membershipEntity.getMembershipId()),
+                new MembershipName(membershipEntity.getName()),
+                new MembershipEmail(membershipEntity.getMembershipEmail()),
+                new MembershipAddress(membershipEntity.getAddress()),
+                new MembershipIsValid(membershipEntity.isValid()),
+                new RegisterCreatedAt(membershipEntity.getCreatedAt()),
+                new InfoModifiedAt(membershipEntity.getModifiedAt())
         );
     }
+
+    public MembershipEntity mapToEntity(Membership membership) {
+        return MembershipEntity.of(
+                        membership.getMembershipId(),
+                        membership.getMembershipPw(),
+                        membership.getMembershipEmail(),
+                        membership.getName(),
+                        membership.getAddress(),
+                        membership.isValid(),
+                        membership.getCreatedAt(),
+                        membership.getModifiedAt(),
+                        null
+        );
+    }
+
 }

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipPersistenceAdapter.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipPersistenceAdapter.java
@@ -1,55 +1,54 @@
 package com.yun.membership.adapter.out.persistence;
 
+import com.yun.common.PersistenceAdapter;
 import com.yun.membership.application.port.out.ModifyMembershipPort;
 import com.yun.membership.application.port.out.ReadMembershipPort;
 import com.yun.membership.application.port.out.RegisterMembershipPort;
 import com.yun.membership.domain.Membership;
-import com.yun.common.PersistenceAdapter;
+import com.yun.membership.domain.ModifyMembership;
+import com.yun.membership.exception.MembershipModuleException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import static com.yun.membership.exception.MembershipErrorCode.USER_NOTFOUND_ACCOUNT;
+
 @PersistenceAdapter
 @RequiredArgsConstructor
 public class MembershipPersistenceAdapter implements RegisterMembershipPort, ReadMembershipPort, ModifyMembershipPort {
+
     private final MembershipJpaRepository membershipJpaRepository;
     private final MembershipMapper mapper;
     @Override
     public Membership createdMembership(Membership membership) {
-        MembershipEntity membershipEntity = membershipJpaRepository.save(MembershipEntity.of(
-                membership.getName(),
-                membership.getAddress(),
-                membership.getEmail(),
-                membership.isValid(),
-                membership.isCorp()
-        ));
-        return mapper.mapToDomainEntity(membershipEntity);
+        MembershipEntity membershipEntity = membershipJpaRepository.save(mapper.mapToEntity(membership));
+        return mapper.mapToMembership(membershipEntity);
     }
 
     @Override
-    public Membership findByMembershipId(Membership.MembershipId membershipId) {
-        MembershipEntity byMembershipId = membershipJpaRepository.findById(Long.valueOf(membershipId.getId()))
+    public Membership findByMembershipId(String membershipId) {
+        MembershipEntity membershipEntity = membershipJpaRepository.findById(membershipId)
                 .orElseThrow(() -> {
-                    throw new EntityNotFoundException("회원을 찾을 수 없습니다");
+                    throw new MembershipModuleException(USER_NOTFOUND_ACCOUNT, USER_NOTFOUND_ACCOUNT.getMessage());
                 });
-        return mapper.mapToDomainEntity(byMembershipId);
+        return mapper.mapToMembership(membershipEntity);
     }
 
     @Override
     public Page<Membership> findAllMembership(Pageable pageable) {
         return membershipJpaRepository.findAll(pageable)
-                .map(membershipEntity -> mapper.mapToDomainEntity(membershipEntity));
+                .map(membershipEntity -> mapper.mapToMembership(membershipEntity));
     }
 
     @Override
-    public Membership updateMembershipInfo(Membership membership) {
-        MembershipEntity getMembership = membershipJpaRepository.findById(Long.parseLong(membership.getMembershipId()))
+    public Membership updateMembershipInfo(ModifyMembership modifyMembership) {
+        MembershipEntity getMembership = membershipJpaRepository.findById(modifyMembership.getMembershipId())
                 .orElseThrow(() -> {
                     throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다");
                 });
         //TODO: email 수정시에는 해당 회원의 이메일 인증이 필요하다
-        getMembership.updateMembershipInfo(membership.getName(), membership.getAddress());
-        return mapper.mapToDomainEntity(membershipJpaRepository.save(getMembership));
+        getMembership.updateMembershipInfo(modifyMembership.getMembershipId(), modifyMembership.getAddress());
+        return mapper.mapToMembership(membershipJpaRepository.save(getMembership));
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipPersistenceAdapter.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipPersistenceAdapter.java
@@ -7,7 +7,6 @@ import com.yun.membership.application.port.out.RegisterMembershipPort;
 import com.yun.membership.domain.Membership;
 import com.yun.membership.domain.ModifyMembership;
 import com.yun.membership.exception.MembershipModuleException;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -45,9 +44,9 @@ public class MembershipPersistenceAdapter implements RegisterMembershipPort, Rea
     public Membership updateMembershipInfo(ModifyMembership modifyMembership) {
         MembershipEntity getMembership = membershipJpaRepository.findById(modifyMembership.getMembershipId())
                 .orElseThrow(() -> {
-                    throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다");
+                    throw new MembershipModuleException(USER_NOTFOUND_ACCOUNT, USER_NOTFOUND_ACCOUNT.getMessage());
                 });
-        //TODO: email 수정시에는 해당 회원의 이메일 인증이 필요하다
+
         getMembership.updateMembershipInfo(modifyMembership.getMembershipId(), modifyMembership.getAddress());
         return mapper.mapToMembership(membershipJpaRepository.save(getMembership));
     }

--- a/membership-service/src/main/java/com/yun/membership/application/port/in/ModifyMembershipCommand.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/in/ModifyMembershipCommand.java
@@ -10,31 +10,30 @@ import lombok.Getter;
 
 import static com.yun.membership.domain.ModifyMembership.*;
 
+/**
+ * 회원 정보 수정
+ * email, password 수정의 경우 본인 인증 및 검증이 필요하므로 API 분리
+ */
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ModifyMembershipCommand extends SelfValidating<ModifyMembershipRequest> {
     @NotNull
     @NotEmpty
     private final String membershipId;
-    private final String name;
-    private final String email;
     private final String address;
 
-    private ModifyMembershipCommand(String membershipId, String name, String email, String address) {
+    private ModifyMembershipCommand(String membershipId, String address) {
         this.membershipId = membershipId;
-        this.name = name;
-        this.email = email;
         this.address = address;
     }
 
-    public static ModifyMembershipCommand of(String membershipId, String name, String email, String address) {
-        return new ModifyMembershipCommand(membershipId, name, email, address);
+    public static ModifyMembershipCommand of(String membershipId, String address) {
+        return new ModifyMembershipCommand(membershipId, address);
     }
 
     public ModifyMembership toMembership() {
-        return generateInMember(
+        return generateInModifyMember(
                 new MembershipId(membershipId),
-                new MembershipAddress(address),
-                new MembershipEmail(email));
+                new MembershipAddress(address));
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/application/port/in/ModifyMembershipCommand.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/in/ModifyMembershipCommand.java
@@ -1,12 +1,14 @@
 package com.yun.membership.application.port.in;
 
-import com.yun.membership.adapter.in.web.model.request.ModifyMembershipRequest;
-import com.yun.membership.domain.Membership;
 import com.yun.common.SelfValidating;
+import com.yun.membership.adapter.in.web.model.request.ModifyMembershipRequest;
+import com.yun.membership.domain.ModifyMembership;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+
+import static com.yun.membership.domain.ModifyMembership.*;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
@@ -17,28 +19,22 @@ public class ModifyMembershipCommand extends SelfValidating<ModifyMembershipRequ
     private final String name;
     private final String email;
     private final String address;
-    private final boolean isCorp;
 
-    private ModifyMembershipCommand(String membershipId, String name, String email, String address, boolean isCorp) {
+    private ModifyMembershipCommand(String membershipId, String name, String email, String address) {
         this.membershipId = membershipId;
         this.name = name;
         this.email = email;
         this.address = address;
-        this.isCorp = isCorp;
     }
 
-    public static ModifyMembershipCommand of(String membershipId, String name, String email, String address, boolean isCorp) {
-        return new ModifyMembershipCommand(membershipId, name, email, address, isCorp);
+    public static ModifyMembershipCommand of(String membershipId, String name, String email, String address) {
+        return new ModifyMembershipCommand(membershipId, name, email, address);
     }
 
-    public Membership toMembership() {
-        return Membership.generateMember(
-                new Membership.MembershipId(membershipId),
-                new Membership.MembershipName(name),
-                new Membership.MembershipEmail(email),
-                new Membership.MembershipAddress(address),
-                new Membership.MembershipIsValid(true),
-                new Membership.MembershipIsCorp(isCorp)
-        );
+    public ModifyMembership toMembership() {
+        return generateInMember(
+                new MembershipId(membershipId),
+                new MembershipAddress(address),
+                new MembershipEmail(email));
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/application/port/in/ReadMembershipCommand.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/in/ReadMembershipCommand.java
@@ -9,7 +9,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ReadMembershipCommand extends SelfValidating<ReadMembershipRequest> {
     @NotNull
     @NotBlank
@@ -17,13 +17,10 @@ public class ReadMembershipCommand extends SelfValidating<ReadMembershipRequest>
 
     private ReadMembershipCommand(String membershipId) {
         this.membershipId = membershipId;
+        this.validateSelf();
     }
 
     public static ReadMembershipCommand of(String membershipId) {
         return new ReadMembershipCommand(membershipId);
-    }
-
-    public Membership.MembershipId toMembershipId() {
-        return new Membership.MembershipId(membershipId);
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/application/port/in/RegisterMembershipCommand.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/in/RegisterMembershipCommand.java
@@ -1,47 +1,68 @@
 package com.yun.membership.application.port.in;
 
-import com.yun.membership.domain.Membership;
 import com.yun.common.SelfValidating;
-import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import com.yun.membership.domain.Membership;
+import jakarta.validation.constraints.*;
 import lombok.EqualsAndHashCode;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RegisterMembershipCommand extends SelfValidating<RegisterMembershipCommand> {
     @NotNull
     @NotBlank
-    private final String name;
+    private final String membershipId;
+
     @NotNull
     @NotBlank
-    private final String email;
+    @Pattern(regexp="(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}",
+            message = "비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상씩 포함된 8자 ~ 20자의 비밀번호여야 합니다.")
+    private final String membershipPw;
+
+    @Email
+    @NotBlank
+    private final String membershipEmail;
+
+    @NotNull
+    @NotBlank
+    private final String name;
+
     @NotNull
     @NotBlank
     private final String address;
-    @AssertTrue
-    private final boolean isValid; //내부 시스템 admin에서 권한을 변경할 수 있다
-    private final boolean isCorp;
 
-    private RegisterMembershipCommand(String name, String email, String address, boolean isValid, boolean isCorp) {
+    @AssertFalse
+    private final boolean isValid; //내부 시스템 admin에서 권한을 변경할 수 있다
+
+    private RegisterMembershipCommand(String membershipId,
+                                     String membershipPw,
+                                     String membershipEmail,
+                                     String name,
+                                     String address,
+                                     boolean isValid) {
+        this.membershipId = membershipId;
+        this.membershipPw = membershipPw;
+        this.membershipEmail = membershipEmail;
         this.name = name;
-        this.email = email;
         this.address = address;
         this.isValid = isValid;
-        this.isCorp = isCorp;
     }
 
-    public static RegisterMembershipCommand of(String name, String email, String address, boolean isValid, boolean isCorp) {
-        return new RegisterMembershipCommand(name, email, address, isValid, isCorp);
+    public static RegisterMembershipCommand of(String membershipId,
+                                     String membershipPw,
+                                     String membershipEmail,
+                                     String name,
+                                     String address,
+                                     boolean isValid) {
+        return new RegisterMembershipCommand(membershipId, membershipPw, membershipEmail, name, address, isValid);
     }
 
     public Membership toMembership() {
-        return Membership.generateMember(
-                new Membership.MembershipId(null),
+        return Membership.generateInMember(
+                new Membership.MembershipId(membershipId),
+                new Membership.MembershipPw(membershipPw),
                 new Membership.MembershipName(name),
-                new Membership.MembershipEmail(email),
+                new Membership.MembershipEmail(membershipEmail),
                 new Membership.MembershipAddress(address),
-                new Membership.MembershipIsValid(isValid),
-                new Membership.MembershipIsCorp(isCorp)
+                new Membership.MembershipIsValid(isValid)
         );
     }
 

--- a/membership-service/src/main/java/com/yun/membership/application/port/in/RegisterMembershipUseCase.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/in/RegisterMembershipUseCase.java
@@ -3,5 +3,10 @@ package com.yun.membership.application.port.in;
 import com.yun.membership.domain.Membership;
 
 public interface RegisterMembershipUseCase {
+    /**
+     * 회원가입
+     * 존재하지 않는 회원: 데이터 검증 후 회원가입 진행
+     * 존재하는 회원: 예외처리 MembershipErrorCode
+     */
     Membership registerMembership(RegisterMembershipCommand command);
 }

--- a/membership-service/src/main/java/com/yun/membership/application/port/out/ModifyMembershipPort.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/out/ModifyMembershipPort.java
@@ -1,7 +1,8 @@
 package com.yun.membership.application.port.out;
 
 import com.yun.membership.domain.Membership;
+import com.yun.membership.domain.ModifyMembership;
 
 public interface ModifyMembershipPort {
-    Membership updateMembershipInfo(Membership membership);
+    Membership updateMembershipInfo(ModifyMembership modifyMembership);
 }

--- a/membership-service/src/main/java/com/yun/membership/application/port/out/ReadMembershipPort.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/out/ReadMembershipPort.java
@@ -5,6 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ReadMembershipPort {
-    Membership findByMembershipId(Membership.MembershipId membershipId);
+    Membership findByMembershipId(String membershipId);
     Page<Membership> findAllMembership(Pageable pageable);
 }

--- a/membership-service/src/main/java/com/yun/membership/application/service/ModifyMembershipService.java
+++ b/membership-service/src/main/java/com/yun/membership/application/service/ModifyMembershipService.java
@@ -3,11 +3,16 @@ package com.yun.membership.application.service;
 import com.yun.membership.application.port.in.ModifyMembershipCommand;
 import com.yun.membership.application.port.in.ModifyMembershipUseCase;
 import com.yun.membership.application.port.out.ModifyMembershipPort;
+import com.yun.membership.application.port.out.ReadMembershipPort;
 import com.yun.membership.domain.Membership;
 import com.yun.common.UseCase;
+import com.yun.membership.exception.MembershipErrorCode;
+import com.yun.membership.exception.MembershipModuleException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.yun.membership.exception.MembershipErrorCode.*;
 
 @Slf4j
 @UseCase
@@ -16,8 +21,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class ModifyMembershipService implements ModifyMembershipUseCase {
 
     private final ModifyMembershipPort modifyMembershipPort;
+    //TODO: readMembership의 경우 캐싱을 통해 반복적인 DB 접근을 줄이며, 시큐리티를 통해 앞단에서 검증 하도록 개선 필요.
+    private final ReadMembershipPort readMembershipPort;
     @Override
     public Membership modifyMembershipInfo(ModifyMembershipCommand command) {
+        if (!readMembershipPort.findByMembershipId(command.getMembershipId()).isValid()) {
+            throw new MembershipModuleException(USER_NOTFOUND_ACCOUNT, USER_NOTFOUND_ACCOUNT.getMessage());
+        }
         return modifyMembershipPort.updateMembershipInfo(command.toMembership());
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/application/service/ReadMembershipService.java
+++ b/membership-service/src/main/java/com/yun/membership/application/service/ReadMembershipService.java
@@ -26,6 +26,6 @@ public class ReadMembershipService implements ReadMembershipUseCase {
 
     @Override
     public Membership getMembershipsByMemberId(ReadMembershipCommand membershipIdCommand) {
-        return readMembershipPort.findByMembershipId(membershipIdCommand.toMembershipId());
+        return readMembershipPort.findByMembershipId(membershipIdCommand.getMembershipId());
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/application/service/RegisterMembershipService.java
+++ b/membership-service/src/main/java/com/yun/membership/application/service/RegisterMembershipService.java
@@ -1,13 +1,17 @@
 package com.yun.membership.application.service;
 
+import com.yun.common.UseCase;
 import com.yun.membership.application.port.in.RegisterMembershipCommand;
 import com.yun.membership.application.port.in.RegisterMembershipUseCase;
+import com.yun.membership.application.port.out.ReadMembershipPort;
 import com.yun.membership.application.port.out.RegisterMembershipPort;
 import com.yun.membership.domain.Membership;
-import com.yun.common.UseCase;
+import com.yun.membership.exception.MembershipModuleException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.yun.membership.exception.MembershipErrorCode.USER_ALREADY_EXIST_ACCOUNT;
 
 @Slf4j
 @UseCase
@@ -16,8 +20,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class RegisterMembershipService implements RegisterMembershipUseCase {
 
     private final RegisterMembershipPort registerMembershipPort;
+    private final ReadMembershipPort readMembershipPort;
     @Override
     public Membership registerMembership(RegisterMembershipCommand command) {
-        return registerMembershipPort.createdMembership(command.toMembership());
+
+        try {
+            //존재하면 예외처리 : USER_ALREADY_EXIST_ACCOUNT
+            readMembershipPort.findByMembershipId(command.toMembership().getMembershipId());
+        } catch (MembershipModuleException findMembershipException) {
+            //존재하지 않으면 저장
+            log.info("findMembershipException : {} | {} : 회원 가입 가능: ", findMembershipException, command.toMembership().getMembershipId());
+            return registerMembershipPort.createdMembership(command.toMembership());
+        }
+
+        throw new MembershipModuleException(USER_ALREADY_EXIST_ACCOUNT, USER_ALREADY_EXIST_ACCOUNT.getMessage());
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/domain/Membership.java
+++ b/membership-service/src/main/java/com/yun/membership/domain/Membership.java
@@ -2,77 +2,126 @@ package com.yun.membership.domain;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Membership {
+
     private String membershipId;
+    private String membershipPw;
+    private String membershipEmail;
     private String name;
-    private String email;
     private String address;
     private boolean isValid;
-    private boolean isCorp;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
 
-    public static Membership generateMember(MembershipId membershipId,
-                                            MembershipName membershipName,
-                                            MembershipEmail membershipEmail,
-                                            MembershipAddress membershipAddress,
-                                            MembershipIsValid membershipIsValid,
-                                            MembershipIsCorp membershipIsCorp) {
+    public static Membership generateInMember(MembershipId membershipId,
+                                              MembershipPw membershipPw,
+                                              MembershipName membershipName,
+                                              MembershipEmail membershipEmail,
+                                              MembershipAddress membershipAddress,
+                                              MembershipIsValid membershipIsValid) {
         return new Membership(
                 membershipId.id,
+                membershipPw.password,
                 membershipName.name,
                 membershipEmail.email,
                 membershipAddress.address,
                 membershipIsValid.isValid,
-                membershipIsCorp.isCorp);
+                LocalDateTime.now(),
+                LocalDateTime.now());
+    }
+
+    public static Membership generateOutMember(MembershipId membershipId,
+                                               MembershipName membershipName,
+                                               MembershipEmail membershipEmail,
+                                               MembershipAddress membershipAddress,
+                                               MembershipIsValid membershipIsValid,
+                                               RegisterCreatedAt registerCreatedAt,
+                                               InfoModifiedAt infoModifiedAt) {
+        return new Membership(
+                membershipId.id,
+                null,
+                membershipName.name,
+                membershipEmail.email,
+                membershipAddress.address,
+                membershipIsValid.isValid,
+                registerCreatedAt.createdAt,
+                infoModifiedAt.modifiedAt);
     }
 
     @Value
-    public static class MembershipId{
+    public static class MembershipId {
         String id;
+
         public MembershipId(String value) {
             this.id = value;
         }
     }
 
     @Value
-    public static class MembershipName{
+    public static class MembershipPw {
+        String password;
+
+        public MembershipPw(String value) {
+            this.password = value;
+        }
+    }
+
+    @Value
+    public static class MembershipName {
         String name;
+
         public MembershipName(String value) {
             this.name = value;
         }
     }
 
     @Value
-    public static class MembershipEmail{
+    public static class MembershipEmail {
         String email;
+
         public MembershipEmail(String value) {
             this.email = value;
         }
     }
 
     @Value
-    public static class MembershipAddress{
+    public static class MembershipAddress {
         String address;
+
         public MembershipAddress(String value) {
             this.address = value;
         }
     }
 
     @Value
-    public static class MembershipIsValid{
+    public static class MembershipIsValid {
         boolean isValid;
+
         public MembershipIsValid(boolean value) {
             this.isValid = value;
         }
     }
 
     @Value
-    public static class MembershipIsCorp{
-        boolean isCorp;
-        public MembershipIsCorp(boolean value) {
-            this.isCorp = value;
+    public static class RegisterCreatedAt {
+        LocalDateTime createdAt;
+
+        public RegisterCreatedAt(LocalDateTime value) {
+            this.createdAt = value;
+        }
+    }
+
+    @Value
+    public static class InfoModifiedAt {
+        LocalDateTime modifiedAt;
+
+        public InfoModifiedAt(LocalDateTime value) {
+            this.modifiedAt = value;
         }
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/domain/ModifyMembership.java
+++ b/membership-service/src/main/java/com/yun/membership/domain/ModifyMembership.java
@@ -1,0 +1,49 @@
+package com.yun.membership.domain;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ModifyMembership {
+    private String membershipId;
+    private String membershipEmail;
+    private String address;
+
+    public static ModifyMembership generateInMember(MembershipId membershipId,
+                                              MembershipAddress membershipAddress,
+                                              MembershipEmail membershipEmail) {
+        return new ModifyMembership(
+                membershipId.id,
+                membershipAddress.address,
+                membershipEmail.email);
+    }
+
+    @Value
+    public static class MembershipId {
+        String id;
+
+        public MembershipId(String value) {
+            this.id = value;
+        }
+    }
+
+    @Value
+    public static class MembershipAddress {
+        String address;
+
+        public MembershipAddress(String value) {
+            this.address = value;
+        }
+    }
+
+    @Value
+    public static class MembershipEmail {
+        String email;
+
+        public MembershipEmail(String value) {
+            this.email = value;
+        }
+    }
+
+}

--- a/membership-service/src/main/java/com/yun/membership/domain/ModifyMembership.java
+++ b/membership-service/src/main/java/com/yun/membership/domain/ModifyMembership.java
@@ -6,17 +6,15 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ModifyMembership {
+
     private String membershipId;
-    private String membershipEmail;
     private String address;
 
-    public static ModifyMembership generateInMember(MembershipId membershipId,
-                                              MembershipAddress membershipAddress,
-                                              MembershipEmail membershipEmail) {
+    public static ModifyMembership generateInModifyMember(MembershipId membershipId,
+                                                          MembershipAddress membershipAddress) {
         return new ModifyMembership(
                 membershipId.id,
-                membershipAddress.address,
-                membershipEmail.email);
+                membershipAddress.address);
     }
 
     @Value
@@ -34,15 +32,6 @@ public class ModifyMembership {
 
         public MembershipAddress(String value) {
             this.address = value;
-        }
-    }
-
-    @Value
-    public static class MembershipEmail {
-        String email;
-
-        public MembershipEmail(String value) {
-            this.email = value;
         }
     }
 

--- a/money-service/src/main/java/com/yun/money/adapter/in/kafka/RechargingMoneyResultConsumer.java
+++ b/money-service/src/main/java/com/yun/money/adapter/in/kafka/RechargingMoneyResultConsumer.java
@@ -57,11 +57,11 @@ public class RechargingMoneyResultConsumer {
                         log.info("received message: key = {}, value = {}", record.key(), record.value());
 
                         //record: RechargingMoneyTask all subtask is done
-                        try {
+                        /*try {
                             Thread.sleep(3000);
                         } catch (InterruptedException e) {
                             throw new RuntimeException(e);
-                        }
+                        }*/
 
                         RechargingMoneyTask task;
                         try {


### PR DESCRIPTION
### membership 회원가입 검증 로직 리팩토링
- membership entity 컬럼 재설계
- entity 재설계에 따른  model 데이터 수정
### 회원 가입 로직 리팩토링
- 회원가입시 존재하는 회원인지 검증하는 서비스 로직 추가
- 이미 가입된 멤버라면 예외처리 반환
### 회원가입시 회원 활성화 상태 true 변경
- 회원가입시 isValid 상태가 false로 들어가는 것을 정상적으로 저장됐을 때 true로 데이터가 들어가도록 수정
### 회원 정보 수정(membershipId, address)
- email, password 수정의 경우 본인 인증 및 검증이 필요하므로 API 분리
- 예외처리 반환 추가
- 코드 정리