### PR TITLE
Feature/#100 money search data

### DIFF
--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/in/axon/MoneyAdjustEventHandler.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/in/axon/MoneyAdjustEventHandler.java
@@ -1,0 +1,29 @@
+package com.yun.moneyqueryservice.adapter.in.axon;
+
+import com.yun.moneyqueryservice.application.port.out.GetMemberAddressInfoPort;
+import com.yun.moneyqueryservice.application.port.out.InsertMoneyIncreaseEventByAddress;
+import com.yun.moneyqueryservice.application.port.out.MemberAddressInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.axonframework.eventhandling.EventHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class MoneyAdjustEventHandler {
+    @EventHandler
+    public void handler(RequestFirmbankingFinishedEvent event
+            , GetMemberAddressInfoPort getMemberAddressInfoPort
+            , InsertMoneyIncreaseEventByAddress insertMoneyIncreaseEventByAddress) {
+        log.info("money adjust event receiced : {}", event.toString());
+
+        //고객 주소 정보
+        MemberAddressInfo memberAddressInfo = getMemberAddressInfoPort.getMemberAddressInfo(event.getMembershipId());
+
+        //dynamoDB insert
+        String address = memberAddressInfo.address();
+        int moneyAmount = event.getMoneyAmount();
+        log.info("dynamo insert: {}, {}", address, moneyAmount);
+
+        insertMoneyIncreaseEventByAddress.insertMoneyIncreaseEventByAddress(address, moneyAmount);
+    }
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/in/axon/RequestFirmbankingFinishedEvent.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/in/axon/RequestFirmbankingFinishedEvent.java
@@ -1,0 +1,19 @@
+package com.yun.moneyqueryservice.adapter.in.axon;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestFirmbankingFinishedEvent {
+    private String requestFirmbankingId;
+    private String rechargingRequestId;
+    private String membershipId;
+    private String toBankName;
+    private String toBankAccountNumber;
+    private int moneyAmount; // only won
+    private int status;
+    private String requestFirmbankingAggregateIdentifier;
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/in/web/MoneyQueryController.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/in/web/MoneyQueryController.java
@@ -1,0 +1,29 @@
+package com.yun.moneyqueryservice.adapter.in.web;
+
+import com.yun.common.anotation.WebAdapter;
+import com.yun.moneyqueryservice.application.port.in.QueryMoneySumByRegionQuery;
+import com.yun.moneyqueryservice.application.port.in.QueryMoneySumRegionUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@WebAdapter
+@RequestMapping("/money/query")
+public class MoneyQueryController {
+
+    private final QueryMoneySumRegionUseCase queryMoneySumRegionUseCase;
+
+    @GetMapping("/get-money-sum-by-address")
+    public long getMoneySumByAddress(@RequestParam("addressKeyword") String addressKeyword) {
+        QueryMoneySumByRegionQuery query = QueryMoneySumByRegionQuery.builder()
+                .address(addressKeyword)
+                .build();
+        return queryMoneySumRegionUseCase.queryMoneySumByRegion(query).getMoneySum();
+    }
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/out/aws/dynamodb/DynamoDBAdapter.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/out/aws/dynamodb/DynamoDBAdapter.java
@@ -1,0 +1,236 @@
+package com.yun.moneyqueryservice.adapter.out.aws.dynamodb;
+
+import com.yun.moneyqueryservice.application.port.out.GetMemberAddressInfoPort;
+import com.yun.moneyqueryservice.application.port.out.InsertMoneyIncreaseEventByAddress;
+import com.yun.moneyqueryservice.application.port.out.MemberAddressInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class DynamoDBAdapter implements GetMemberAddressInfoPort, InsertMoneyIncreaseEventByAddress {
+    @Value("money.query.table")
+    private String TABLE_NAME;
+    @Value("money.dynamo.access")
+    private String ACCESS_KEY;
+    @Value("money.dynamo.secret")
+    private String SECRET_KEY;
+    private final DynamoDbClient dynamoDbClient;
+    private final MoneySumByAddressMapper mapper;
+
+    public DynamoDBAdapter() {
+        this.mapper = new MoneySumByAddressMapper();
+        AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY);
+        this.dynamoDbClient = DynamoDbClient.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
+                .build();
+    }
+
+    /*@Override
+    public void insertMoneyIncreaseEventByAddress(String addressName, int moneyIncrease) {
+        //1. raw event insert
+        String pk = addressName + "#" + LocalDateTime.now();
+        int sk = moneyIncrease;
+        putItem(pk, sk);
+
+        //2. 지역 정보 잔액 증가
+        //2-1. 지역별/일별 정보
+        String summaryPk = pk + "summary";
+        int summarySk = -1;
+        MoneySumByAddress item = getItem(summaryPk, summarySk);
+        if (item == null) {
+            putItem(summaryPk, summarySk, moneyIncrease);
+        }
+
+        //합산 TODO: domain으로 분리
+        int balance = item.getBalance();
+        balance += moneyIncrease;
+        //update
+
+        //2-2. 지역별 정보
+        String addressPk = addressName;
+        int addressSk = -1;
+        MoneySumByAddress addressItem = getItem(addressPk, addressSk);
+        if (addressItem == null) {
+            putItem(addressPk, addressSk, moneyIncrease);
+        }
+        //합산 TODO: domain으로 분리
+        int addressItemBalance = addressItem.getBalance();
+        addressItemBalance += moneyIncrease;
+        putItem(addressPk, addressSk, addressItemBalance);
+    }*/
+
+    @Override
+    public void insertMoneyIncreaseEventByAddress(String addressName, int moneyIncrease) {
+        // 3개의 일을 해야될 것이에요.
+
+        // 1. raw event insert (Insert, put)
+        // PK: 강남구#230728 SK: 5,000, balance, 5,000
+        String pk = addressName + "#" + "230728";
+        int sk = moneyIncrease;
+        putItem(pk, sk, moneyIncrease);
+
+        // 2. 지역 정보 잔액 증가시켜야 해요. (Query, Update)
+        // 2-1. 지역별/일별 정보
+        //  - PK: 강남구#230728#summary SK: -1 balance: + 5,000
+        String summaryPk = pk + "#summary";
+        int summarySk = -1;
+        MoneySumByAddress moneySumByAddress = getItem(summaryPk, summarySk);
+        if (moneySumByAddress == null) {
+            putItem(summaryPk, summarySk, moneyIncrease);
+        } else{
+            int balance = moneySumByAddress.getBalance();
+            balance += moneyIncrease;
+            updateItem(summaryPk, summarySk, balance);
+        }
+
+        // 2-2. 지역별 정보
+        // - PK: 강남구 SK: -1 balance: + 5,000
+        String summaryPk2 = addressName;
+        int summarySk2 = -1;
+        MoneySumByAddress moneySumByAddress2 = getItem(summaryPk2, summarySk2);
+        if (moneySumByAddress2 == null) {
+            putItem(summaryPk2, summarySk2, moneyIncrease);
+        } else{
+            int balance2 = moneySumByAddress2.getBalance();
+            balance2 += moneyIncrease;
+            updateItem(summaryPk2, summarySk2, balance2);
+        }
+    }
+
+    @Override
+    public MemberAddressInfo getMemberAddressInfo(String membershipId) {
+        return null;
+    }
+
+    private MoneySumByAddress getItem(String pk, int sk) {
+        try {
+            HashMap<String, AttributeValue> attrMap = new HashMap<>();
+            attrMap.put("PK", AttributeValue.builder().s(pk).build());
+            attrMap.put("SK", AttributeValue.builder().n(Integer.toString(sk)).build());
+
+            GetItemRequest request = GetItemRequest.builder()
+                    .tableName(TABLE_NAME)
+                    .key(attrMap)
+                    .build();
+
+            GetItemResponse response = dynamoDbClient.getItem(request);
+
+            if (response.hasItem()) {
+                mapper.mapToMoneySumByAddress(response.item());
+            }
+
+        } catch (DynamoDbException e) {
+            log.error("Error getting an item from the table: {} ", e.getMessage());
+        }
+        return null;
+    }
+
+    private void putItem(String pk, int sk) {
+        try {
+            HashMap<String, AttributeValue> attrMap = new HashMap<>();
+            attrMap.put("PK", AttributeValue.builder().s(pk).build());
+            attrMap.put("SK", AttributeValue.builder().s(Integer.toString(sk)).build());
+
+            PutItemRequest request = PutItemRequest.builder()
+                    .tableName(TABLE_NAME)
+                    .item(attrMap)
+                    .build();
+
+            dynamoDbClient.putItem(request);
+        } catch (DynamoDbException e) {
+            log.error("Error adding an item to the table: {} ", e.getMessage());
+        }
+    }
+
+    private void putItem(String pk, int sk, int balance) {
+        try {
+            HashMap<String, AttributeValue> attrMap = new HashMap<>();
+            attrMap.put("PK", AttributeValue.builder().s(pk).build());
+            attrMap.put("SK", AttributeValue.builder().s(Integer.toString(sk)).build());
+            attrMap.put("Balance", AttributeValue.builder().n(Integer.toString(balance)).build());
+
+            PutItemRequest request = PutItemRequest.builder()
+                    .tableName(TABLE_NAME)
+                    .item(attrMap)
+                    .build();
+
+            dynamoDbClient.putItem(request);
+        } catch (DynamoDbException e) {
+            log.error("Error adding an item to the table: {} ", e.getMessage());
+        }
+    }
+
+    private void queryItem(String pk) {
+        try {
+            // PK 만 써도 돼요.
+            HashMap<String, Condition> attrMap = new HashMap<>();
+            attrMap.put("PK", Condition.builder()
+                    .attributeValueList(AttributeValue.builder().s(pk).build())
+                    .comparisonOperator(ComparisonOperator.EQ)
+                    .build());
+
+            QueryRequest request = QueryRequest.builder()
+                    .tableName(TABLE_NAME)
+                    .keyConditions(attrMap)
+                    .build();
+
+            QueryResponse response = dynamoDbClient.query(request);
+            response.items().forEach((value) -> log.info("value: {}", value));
+        } catch (DynamoDbException e) {
+            log.error("Error getting an item from the table: {} ", e.getMessage());
+        }
+    }
+
+    private void updateItem(String pk, int sk, int balance) {
+        try {
+            HashMap<String, AttributeValue> attrMap = new HashMap<>();
+            attrMap.put("PK", AttributeValue.builder().s(pk).build());
+            attrMap.put("SK", AttributeValue.builder().s(Integer.toString(sk)).build());
+
+            String balanceStr = String.valueOf(balance);
+            // Create an UpdateItemRequest
+            UpdateItemRequest updateItemRequest = UpdateItemRequest.builder()
+                    .tableName(TABLE_NAME)
+                    .key(attrMap)
+                    .attributeUpdates(
+                            new HashMap<String, AttributeValueUpdate>() {{
+                                put("balance", AttributeValueUpdate.builder()
+                                        .value(AttributeValue.builder().n(balanceStr).build())
+                                        .action(AttributeAction.PUT)
+                                        .build());
+                            }}
+                    ).build();
+
+
+            UpdateItemResponse response = dynamoDbClient.updateItem(updateItemRequest);
+
+            // 결과 출력.
+            Map<String, AttributeValue> attributes = response.attributes();
+            if (attributes != null) {
+                for (Map.Entry<String, AttributeValue> entry : attributes.entrySet()) {
+                    String attributeName = entry.getKey();
+                    AttributeValue attributeValue = entry.getValue();
+                    System.out.println(attributeName + ": " + attributeValue);
+                }
+            } else {
+                System.out.println("Item was updated, but no attributes were returned.");
+            }
+        } catch (DynamoDbException e) {
+            System.err.println("Error getting an item from the table: " + e.getMessage());
+        }
+    }
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/out/aws/dynamodb/MoneySumByAddress.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/out/aws/dynamodb/MoneySumByAddress.java
@@ -1,0 +1,14 @@
+package com.yun.moneyqueryservice.adapter.out.aws.dynamodb;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MoneySumByAddress {
+    private String pk;
+    private String sk;
+    private int balance;
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/out/aws/dynamodb/MoneySumByAddressMapper.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/adapter/out/aws/dynamodb/MoneySumByAddressMapper.java
@@ -1,0 +1,14 @@
+package com.yun.moneyqueryservice.adapter.out.aws.dynamodb;
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.util.Map;
+
+public class MoneySumByAddressMapper {
+    public MoneySumByAddress mapToMoneySumByAddress(Map<String, AttributeValue> item) {
+        return new MoneySumByAddress(
+                item.get("PK").s(),
+                item.get("SK").n(),
+                Integer.parseInt(item.get("balance").n()));
+    }
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/application/port/in/QueryMoneySumByRegionQuery.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/application/port/in/QueryMoneySumByRegionQuery.java
@@ -1,0 +1,13 @@
+package com.yun.moneyqueryservice.application.port.in;
+
+import com.yun.common.SelfValidating;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Builder
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class QueryMoneySumByRegionQuery extends SelfValidating<QueryMoneySumByRegionQuery> {
+    private final String address;
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/application/port/in/QueryMoneySumRegionUseCase.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/application/port/in/QueryMoneySumRegionUseCase.java
@@ -1,0 +1,7 @@
+package com.yun.moneyqueryservice.application.port.in;
+
+import com.yun.moneyqueryservice.domain.MoneySumByRegion;
+
+public interface QueryMoneySumRegionUseCase {
+    MoneySumByRegion queryMoneySumByRegion(QueryMoneySumByRegionQuery query);
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/application/port/out/GetMemberAddressInfoPort.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/application/port/out/GetMemberAddressInfoPort.java
@@ -1,0 +1,5 @@
+package com.yun.moneyqueryservice.application.port.out;
+
+public interface GetMemberAddressInfoPort {
+    MemberAddressInfo getMemberAddressInfo(String membershipId);
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/application/port/out/InsertMoneyIncreaseEventByAddress.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/application/port/out/InsertMoneyIncreaseEventByAddress.java
@@ -1,0 +1,5 @@
+package com.yun.moneyqueryservice.application.port.out;
+
+public interface InsertMoneyIncreaseEventByAddress {
+    void insertMoneyIncreaseEventByAddress(String addressName, int moneyIncrease);
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/application/port/out/MemberAddressInfo.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/application/port/out/MemberAddressInfo.java
@@ -1,0 +1,7 @@
+package com.yun.moneyqueryservice.application.port.out;
+
+public record MemberAddressInfo(
+        String membershipId,
+        String address
+) {
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/application/service/MoneyQueryService.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/application/service/MoneyQueryService.java
@@ -1,0 +1,18 @@
+package com.yun.moneyqueryservice.application.service;
+
+import com.yun.common.anotation.UseCase;
+import com.yun.moneyqueryservice.application.port.in.QueryMoneySumByRegionQuery;
+import com.yun.moneyqueryservice.application.port.in.QueryMoneySumRegionUseCase;
+import com.yun.moneyqueryservice.domain.MoneySumByRegion;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class MoneyQueryService implements QueryMoneySumRegionUseCase {
+    @Override
+    public MoneySumByRegion queryMoneySumByRegion(QueryMoneySumByRegionQuery query) {
+        return null;
+    }
+}

--- a/money-query-service/src/main/java/com/yun/moneyqueryservice/domain/MoneySumByRegion.java
+++ b/money-query-service/src/main/java/com/yun/moneyqueryservice/domain/MoneySumByRegion.java
@@ -1,0 +1,50 @@
+package com.yun.moneyqueryservice.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Value;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MoneySumByRegion {
+    private final String moneySumByRegionId;
+    private final String regionName;
+    private final long moneySum;
+
+    public static MoneySumByRegion generateMoneySumByRegion (
+            MoneySumByRegionId moneySumByRegionId,
+            RegionName regionName,
+            MoneySum moneySum
+    ){
+        return new MoneySumByRegion(
+                moneySumByRegionId.moneySumByRegionId,
+                regionName.regionName,
+                moneySum.moneySum
+        );
+    }
+
+    @Value
+    public static class MoneySumByRegionId {
+        public MoneySumByRegionId(String value) {
+            this.moneySumByRegionId = value;
+        }
+        String moneySumByRegionId ;
+    }
+
+    @Value
+    public static class RegionName {
+        public RegionName(String value) {
+            this.regionName = value;
+        }
+        String regionName ;
+    }
+
+    @Value
+    public static class MoneySum {
+        public MoneySum(int value) {
+            this.moneySum = value;
+        }
+        int moneySum ;
+    }
+}

--- a/money-query-service/src/test/java/com/yun/moneyqueryservice/MoneyQueryServiceApplicationTests.java
+++ b/money-query-service/src/test/java/com/yun/moneyqueryservice/MoneyQueryServiceApplicationTests.java
@@ -1,0 +1,13 @@
+package com.yun.moneyqueryservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MoneyQueryServiceApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
- membership service 서버에서 회원별 주소 검색
- 특정 날짜의 지역별 머니 총 잔액 변동액을 알고 싶다
1/2일날 출금된 머니 총액 등
    - 지역 정보 + 특정 날짜 정보를 기준으로 쿼리
    - 특정 날짜 정보도 PK에 포함
- 특정 날짜의 특정 지역에서 가장 큰 머니의 변동이 있었던 상위 10개의 머니 변동 내역
    - 머니 변동 내역 이벤트 데이터를 각각 모두 저장
    - 머니 변동 금액을 SK로 정의

> money service 에서 3777명의 회원이 조회를 요청할 경우 3777번의 호출을 하는 것이 아니라 
100단위로 묶어서 호출을 한다
10,000명의 고객중에서 “강남구” 고객은 약 3300명으로 max 100, 500 ~ 으로 파티셔닝 단위를 만들어야한다. 이때 우리는 100명 단위로 파티셔닝 하여 요청을 보낼 것

