### PR TITLE
feat: 금융결제원 API 호출 전 데이터 검증

### DIFF
--- a/openbanking-service/src/main/java/com/yun/openbanking/adapter/in/web/model/MemberOAuth2LeggedRequest.java
+++ b/openbanking-service/src/main/java/com/yun/openbanking/adapter/in/web/model/MemberOAuth2LeggedRequest.java
@@ -1,0 +1,13 @@
+package com.yun.openbanking.adapter.in.web.model;
+
+public record MemberOAuth2LeggedRequest(
+        /*@Length(max = 40)
+        @Value("${open-banking.test.client_id}")
+        String clientId,
+        @Value("${open-banking.test.client_secret}")
+        @Length(max = 40)
+        String clientSecret,*/
+        String scope,
+        String grantType
+) {
+}

--- a/openbanking-service/src/main/java/com/yun/openbanking/adapter/out/service/RechargeTransferWithdrawAdapter.java
+++ b/openbanking-service/src/main/java/com/yun/openbanking/adapter/out/service/RechargeTransferWithdrawAdapter.java
@@ -1,6 +1,5 @@
 package com.yun.openbanking.adapter.out.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yun.common.OpenbankingTestUrl;
 import com.yun.common.anotation.ExternalSystemAdapter;
 import com.yun.common.httpclient.CommonRestClient;

--- a/openbanking-service/src/main/java/com/yun/openbanking/domain/Authorize2Legged.java
+++ b/openbanking-service/src/main/java/com/yun/openbanking/domain/Authorize2Legged.java
@@ -1,0 +1,18 @@
+package com.yun.openbanking.domain;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class Authorize2Legged extends MemberAuthorize {
+    private String scope;
+    private String grantType;
+
+    public Authorize2Legged(String scope, String grantType) {
+        this.scope = scope;
+        this.grantType = grantType;
+    }
+}


### PR DESCRIPTION
- 금융결제원 API 호출 전 사용자 데이터 검증 단계를 추가한 뒤 검증된 데이터로 API를 요청한다

closed #120