### PR TITLE
feat: login, logout, register 생성 및 수정

### DIFF
--- a/membership-service/build.gradle
+++ b/membership-service/build.gradle
@@ -9,6 +9,10 @@ compileJava {
 	sourceCompatibility = '17'
 }
 
+ext{
+	axonVersion = "4.9.1"
+}
+
 apply plugin: 'java'
 apply plugin: 'java-library'
 apply plugin: 'org.springframework.boot'
@@ -42,6 +46,13 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 	implementation 'org.springframework.vault:spring-vault-core:3.1.1'
+	implementation group: 'org.axonframework', name: 'axon-configuration', version: "$axonVersion"
+	implementation group: 'org.axonframework', name: 'axon-spring-boot-starter', version: "$axonVersion"
+
+	//ehcache 3
+	implementation 'org.ehcache:ehcache:3.8.1'
+	implementation 'javax.cache:cache-api:1.1.1'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
 	implementation project(':common')
 	implementation project(':logging-service')
@@ -53,6 +64,7 @@ dependencies {
 
 	testImplementation 'com.tngtech.archunit:archunit-junit5:1.2.1'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.axonframework:axon-test:4.9.1' // Axon 프레임워크 테스트 의존성
 	runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
@@ -65,6 +77,8 @@ tasks.withType(Test) {
 	enabled = false
 }
 
+tasks.register("prepareKotlinBuildScriptModel"){}
+
 docker {
 	println(tasks.bootJar.outputs.files)
 	//이미지 이름
@@ -75,4 +89,10 @@ docker {
 	files tasks.bootJar.outputs.files
 	//docker에 전달할 인자
 	buildArgs(['JAR_FILE': tasks.bootJar.outputs.files.singleFile.name])
+}
+
+dependencyManagement {
+	imports {
+		mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2023.0.0'
+	}
 }

--- a/membership-service/src/main/java/com/yun/membership/adapter/axon/RegisterMembershipHandler.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/axon/RegisterMembershipHandler.java
@@ -1,0 +1,29 @@
+package com.yun.membership.adapter.axon;
+
+import com.yun.membership.adapter.axon.model.CacheRegisterMembershipDto;
+import com.yun.membership.application.port.in.event.RegisterMembershipEvent;
+import org.axonframework.eventhandling.EventHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RegisterMembershipHandler {
+
+    private final javax.cache.Cache<String, CacheRegisterMembershipDto> membershipCache;
+
+    public RegisterMembershipHandler(org.springframework.cache.CacheManager springCacheManager) {
+        // Spring CacheManager -> JCacheCacheManager 변환
+        javax.cache.CacheManager jCacheManager =
+                ((org.springframework.cache.jcache.JCacheCacheManager) springCacheManager).getCacheManager();
+
+        this.membershipCache = jCacheManager.getCache("membershipCache", String.class, CacheRegisterMembershipDto.class);
+    }
+
+    @EventHandler
+    public void on(RegisterMembershipEvent event) {
+        // 이벤트로부터 Dto 생성
+        CacheRegisterMembershipDto dto = new CacheRegisterMembershipDto(event.getMembershipId(), event.getMembershipPw(), event.getMembershipEmail());
+        membershipCache.put(event.getMembershipId(), dto);
+        System.out.println("event :" + membershipCache.get(dto.getMembershipId()));
+    }
+
+}

--- a/membership-service/src/main/java/com/yun/membership/adapter/axon/aggregate/MembershipAggregate.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/axon/aggregate/MembershipAggregate.java
@@ -1,0 +1,39 @@
+package com.yun.membership.adapter.axon.aggregate;
+
+import com.yun.membership.application.port.in.RegisterMembershipCommand;
+import com.yun.membership.application.port.in.event.RegisterMembershipEvent;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.spring.stereotype.Aggregate;
+
+import static org.axonframework.modelling.command.AggregateLifecycle.apply;
+
+@Slf4j
+@Getter
+@Aggregate
+public class MembershipAggregate {
+
+    @AggregateIdentifier
+    private String membershipId;
+    private String membershipPw;
+    private String membershipEmail;
+
+    protected MembershipAggregate() {}
+
+    @CommandHandler
+    public MembershipAggregate(RegisterMembershipCommand command) {
+        log.info("RegisterMembershipCommand handler");
+        apply(new RegisterMembershipEvent(command.getMembershipId(), command.getMembershipPw(), command.getMembershipEmail()));
+    }
+
+    @EventSourcingHandler
+    public void on(RegisterMembershipEvent event) {
+        log.info("RegisterMembershipEvent handler: {}", event);
+        membershipId = event.getMembershipId();
+        membershipPw = event.getMembershipPw();
+        membershipEmail = event.getMembershipEmail();
+    }
+}

--- a/membership-service/src/main/java/com/yun/membership/adapter/axon/model/CacheRegisterMembershipDto.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/axon/model/CacheRegisterMembershipDto.java
@@ -1,0 +1,16 @@
+package com.yun.membership.adapter.axon.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.io.Serializable;
+
+@ToString
+@Getter
+@AllArgsConstructor
+public class CacheRegisterMembershipDto implements Serializable {
+    private String membershipId;
+    private String membershipPw;
+    private String membershipEmail;
+}

--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/LoginAdminController.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/LoginAdminController.java
@@ -7,9 +7,7 @@ import com.yun.membership.adapter.in.web.model.request.JwtTokenValidationRequest
 import com.yun.membership.adapter.in.web.model.request.LoginMembershipRequest;
 import com.yun.membership.adapter.in.web.model.request.MembershipRefreshTokenRequest;
 import com.yun.membership.application.port.in.LoginMembershipUseCase;
-import com.yun.membership.jwt.JwtToken;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,14 +17,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.http.HttpResponse;
-
 @Slf4j
 @WebAdapter
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/membership")
-public class LoginMembershipController {
+@RequestMapping("/api/v1/admin")
+public class LoginAdminController {
 
     private final LoginMembershipUseCase loginMembershipUseCase;
 

--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/LogoutMembershipController.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/LogoutMembershipController.java
@@ -1,0 +1,30 @@
+package com.yun.membership.adapter.in.web;
+
+import com.yun.common.anotation.WebAdapter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.logging.Logger;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/membership")
+public class LogoutMembershipController {
+
+    //로그아웃 어노테이션
+    @GetMapping("/logout")
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+
+    }
+
+    @GetMapping("/denied")
+    public void accessDenied(@RequestParam(value = "exception", required = false) String exception) {
+
+    }
+}

--- a/membership-service/src/main/java/com/yun/membership/adapter/in/web/RegisterMembershipController.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/in/web/RegisterMembershipController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @WebAdapter
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/membership")
+@RequestMapping(value = "/api/v1/membership")
 public class RegisterMembershipController {
 
     private final RegisterMembershipUseCase registerMembershipUseCase;

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipEntity.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipEntity.java
@@ -1,5 +1,6 @@
 package com.yun.membership.adapter.out.persistence;
 
+import com.yun.membership.domain.MembershipRole;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -35,6 +36,9 @@ public class MembershipEntity {
     private boolean isValid;
     @Column(name = "is_wallet_available")
     private boolean isMoneyWalletAvailable;
+    @Column(name = "role")
+    @Enumerated(EnumType.STRING)
+    private MembershipRole role;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
@@ -55,6 +59,7 @@ public class MembershipEntity {
                             String refreshToken,
                             boolean isValid,
                             boolean isMoneyWalletAvailable,
+                            MembershipRole role,
                             LocalDateTime createdAt,
                             LocalDateTime modifiedAt,
                             LocalDateTime deletedAt) {
@@ -66,6 +71,7 @@ public class MembershipEntity {
         this.refreshToken = refreshToken;
         this.isValid = isValid;
         this.isMoneyWalletAvailable = isMoneyWalletAvailable;
+        this.role = role;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
         this.deletedAt = deletedAt;

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipMapper.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipMapper.java
@@ -30,6 +30,7 @@ public class MembershipMapper {
                 .address(membership.getAddress())
                 .refreshToken(membership.getRefreshToken())
                 .isMoneyWalletAvailable(false)
+                .role(membership.getRole())
                 .createdAt(membership.getCreatedAt())
                 .modifiedAt(membership.getModifiedAt())
                 .deletedAt(null)

--- a/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipPersistenceAdapter.java
+++ b/membership-service/src/main/java/com/yun/membership/adapter/out/persistence/MembershipPersistenceAdapter.java
@@ -1,15 +1,19 @@
 package com.yun.membership.adapter.out.persistence;
 
 import com.yun.common.anotation.PersistenceAdapter;
+import com.yun.membership.application.port.in.RegisterMembershipCommand;
 import com.yun.membership.application.port.out.ModifyMembershipPort;
 import com.yun.membership.application.port.out.ReadMembershipPort;
 import com.yun.membership.application.port.out.RegisterMembershipPort;
+import com.yun.membership.application.port.out.axon.AxonRegisterMembershipPort;
 import com.yun.membership.domain.Membership;
 import com.yun.membership.domain.ModifyMembership;
 import com.yun.membership.exception.MembershipModuleException;
 import com.yun.membership.jwt.JwtToken;
 import com.yun.membership.vault.VaultAdapter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -18,18 +22,24 @@ import java.util.stream.Collectors;
 
 import static com.yun.membership.exception.MembershipErrorCode.USER_NOTFOUND_ACCOUNT;
 
+@Slf4j
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class MembershipPersistenceAdapter implements RegisterMembershipPort, ReadMembershipPort, ModifyMembershipPort {
+public class MembershipPersistenceAdapter implements RegisterMembershipPort, ReadMembershipPort, ModifyMembershipPort, AxonRegisterMembershipPort {
 
     private final VaultAdapter vaultAdapter;
     private final MembershipJpaRepository membershipJpaRepository;
     private final MembershipMapper mapper;
+    private final CommandGateway axonCommandGateway;
+
+    //command gateway
     @Override
     public Membership createdMembership(Membership membership) {
         //email만 암호화?
         String encryptEmail = vaultAdapter.encrypt(membership.getMembershipEmail());
         MembershipEntity membershipEntity = membershipJpaRepository.save(mapper.mapToEntity(membership, encryptEmail));
+        log.info("createdMembership() adapter 실행: {}", membershipEntity.getMembershipId());
+        //이벤트 전송
         return mapper.mapToMembership(membershipEntity);
     }
 
@@ -75,5 +85,15 @@ public class MembershipPersistenceAdapter implements RegisterMembershipPort, Rea
                 });
         getMembership.insertRefreshToken(jwtToken.getRefreshToken());
         membershipJpaRepository.save(getMembership);
+    }
+
+    /**
+     * Axon command send
+     * @param command
+     */
+    @Override
+    public void send(RegisterMembershipCommand command) {
+        log.info("adapter");
+        axonCommandGateway.send(command);
     }
 }

--- a/membership-service/src/main/java/com/yun/membership/application/port/in/RegisterMembershipCommand.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/in/RegisterMembershipCommand.java
@@ -4,12 +4,14 @@ import com.yun.common.SelfValidating;
 import com.yun.membership.adapter.in.web.model.request.RegisterMembershipRequest;
 import com.yun.membership.domain.Membership;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 /**
  * RegisterMembershipCommand에 isValid : 회원의 활성화(권한) 여부
  * 최초 가입시 기본값 = false -> DB 저장 이후 true 변경
  * 내부 시스템 admin에서 권한을 변경할 수 있다
  */
+@Getter
 @EqualsAndHashCode(callSuper = false)
 public class RegisterMembershipCommand extends SelfValidating<RegisterMembershipRequest> {
 

--- a/membership-service/src/main/java/com/yun/membership/application/port/in/event/RegisterMembershipEvent.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/in/event/RegisterMembershipEvent.java
@@ -1,0 +1,20 @@
+package com.yun.membership.application.port.in.event;
+
+import com.yun.common.SelfValidating;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode(callSuper = false)
+public class RegisterMembershipEvent extends SelfValidating<RegisterMembershipEvent> {
+    private final String membershipId;
+    private final String membershipPw;
+    private final String membershipEmail;
+
+    public RegisterMembershipEvent(String membershipId, String membershipPw, String membershipEmail) {
+        this.membershipId = membershipId;
+        this.membershipPw = membershipPw;
+        this.membershipEmail = membershipEmail;
+        this.validateSelf();
+    }
+}

--- a/membership-service/src/main/java/com/yun/membership/application/port/out/axon/AxonRegisterMembershipPort.java
+++ b/membership-service/src/main/java/com/yun/membership/application/port/out/axon/AxonRegisterMembershipPort.java
@@ -1,0 +1,7 @@
+package com.yun.membership.application.port.out.axon;
+
+import com.yun.membership.application.port.in.RegisterMembershipCommand;
+
+public interface AxonRegisterMembershipPort {
+    void send(RegisterMembershipCommand command);
+}

--- a/membership-service/src/main/java/com/yun/membership/application/service/LoginMembershipService.java
+++ b/membership-service/src/main/java/com/yun/membership/application/service/LoginMembershipService.java
@@ -31,7 +31,6 @@ public class LoginMembershipService implements LoginMembershipUseCase {
     private final LoginInfoValidator loginInfoValidator;
     private final ModifyMembershipPort modifyMembershipPort;
 
-
     @Override
     @Transactional
     public MembershipResult requestLogin(LoginMembershipCommand command) {

--- a/membership-service/src/main/java/com/yun/membership/application/service/RegisterMembershipService.java
+++ b/membership-service/src/main/java/com/yun/membership/application/service/RegisterMembershipService.java
@@ -5,10 +5,12 @@ import com.yun.membership.application.port.in.RegisterMembershipCommand;
 import com.yun.membership.application.port.in.RegisterMembershipUseCase;
 import com.yun.membership.application.port.out.ReadMembershipPort;
 import com.yun.membership.application.port.out.RegisterMembershipPort;
+import com.yun.membership.application.port.out.axon.AxonRegisterMembershipPort;
 import com.yun.membership.domain.Membership;
 import com.yun.membership.exception.MembershipModuleException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.yun.membership.exception.MembershipErrorCode.USER_ALREADY_EXIST_ACCOUNT;
@@ -21,6 +23,9 @@ public class RegisterMembershipService implements RegisterMembershipUseCase {
 
     private final RegisterMembershipPort registerMembershipPort;
     private final ReadMembershipPort readMembershipPort;
+    private final AxonRegisterMembershipPort axonRegisterMembershipPort;
+
+    @Cacheable(value = "membershipCache", key = "#command.membershipId")
     @Override
     public Membership registerMembership(RegisterMembershipCommand command) {
 
@@ -30,7 +35,10 @@ public class RegisterMembershipService implements RegisterMembershipUseCase {
         } catch (MembershipModuleException findMembershipException) {
             //존재하지 않으면 저장
             log.info("findMembershipException : {} | {} : 회원 가입 가능: ", findMembershipException, command.toMembership().getMembershipId());
-            return registerMembershipPort.createdMembership(command.toMembership());
+            //이벤트 처리
+            Membership membership = registerMembershipPort.createdMembership(command.toMembership());
+            axonRegisterMembershipPort.send(command);
+            return membership;
         }
 
         throw new MembershipModuleException(USER_ALREADY_EXIST_ACCOUNT, USER_ALREADY_EXIST_ACCOUNT.getMessage());

--- a/membership-service/src/main/java/com/yun/membership/config/EhcacheConfiguration.java
+++ b/membership-service/src/main/java/com/yun/membership/config/EhcacheConfiguration.java
@@ -1,0 +1,41 @@
+package com.yun.membership.config;
+
+import com.yun.membership.adapter.axon.model.CacheRegisterMembershipDto;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class EhcacheConfiguration {
+
+    @Bean
+    public CacheManager getCacheManager() {
+        CachingProvider provider = Caching.getCachingProvider();
+        CacheManager cacheManager = provider.getCacheManager();
+
+        CacheConfiguration<String , CacheRegisterMembershipDto> configuration
+                = CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, CacheRegisterMembershipDto.class,
+                        ResourcePoolsBuilder.heap(100)
+                                .offheap(10, MemoryUnit.MB))
+                .withExpiry(ExpiryPolicyBuilder.timeToIdleExpiration(Duration.ofMinutes(10)))
+                .build();
+
+        javax.cache.configuration.Configuration<String, CacheRegisterMembershipDto> cacheConfiguration = Eh107Configuration
+                .fromEhcacheCacheConfiguration(configuration);
+
+        cacheManager.createCache("membershipCache", cacheConfiguration);
+        return cacheManager;
+    }
+}

--- a/membership-service/src/main/java/com/yun/membership/config/MembershipConfig.java
+++ b/membership-service/src/main/java/com/yun/membership/config/MembershipConfig.java
@@ -4,6 +4,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan(basePackages = {"com.yun.common", "com.yun.loggingservice"})
+@ComponentScan(basePackages = {"com.yun.common"})
 public class MembershipConfig {
 }

--- a/membership-service/src/main/java/com/yun/membership/domain/Membership.java
+++ b/membership-service/src/main/java/com/yun/membership/domain/Membership.java
@@ -17,6 +17,7 @@ public class Membership {
     private String address;
     private String refreshToken;
     private boolean isValid;
+    private MembershipRole role;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -35,6 +36,7 @@ public class Membership {
                 membershipAddress.address,
                 membershipRefreshToken.refreshToken,
                 membershipIsValid.isValid,
+                MembershipRole.ROLE_USER,
                 LocalDateTime.now(),
                 LocalDateTime.now());
     }
@@ -56,6 +58,7 @@ public class Membership {
                 membershipAddress.address,
                 membershipRefreshToken.refreshToken,
                 membershipIsValid.isValid,
+                MembershipRole.ROLE_USER,
                 registerCreatedAt.createdAt,
                 infoModifiedAt.modifiedAt);
     }
@@ -119,6 +122,15 @@ public class Membership {
 
         public MembershipIsValid(boolean value) {
             this.isValid = value;
+        }
+    }
+
+    @Value
+    public static class MemberRole{
+        MembershipRole role;
+
+        public MemberRole(MembershipRole value) {
+            this.role = value;
         }
     }
 

--- a/membership-service/src/main/java/com/yun/membership/domain/MembershipRole.java
+++ b/membership-service/src/main/java/com/yun/membership/domain/MembershipRole.java
@@ -1,0 +1,14 @@
+package com.yun.membership.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MembershipRole {
+    ROLE_USER("ROLE_USER", "알반회원"),
+    ROLE_ADMIN("ROLE_ADMIN", "관리자");
+
+    private String role;
+    private String roleName;
+}

--- a/membership-service/src/main/java/com/yun/membership/jwt/JwtTokenProvider.java
+++ b/membership-service/src/main/java/com/yun/membership/jwt/JwtTokenProvider.java
@@ -25,10 +25,11 @@ public class JwtTokenProvider implements LoginAuthTokenPort {
     private Long jwtExpirationInMs;
     private Long refreshTokenExpirationInMs;
 
-    public JwtTokenProvider(@Value("${service.jwt.secret-key}") String jwtSecretKey) {
+    public JwtTokenProvider(@Value("${service.jwt.secretkey}") String jwtSecretKey) {
         // 516 bit 알고리즘 지원을 위한 비밀키
         // 512 bit = 64byte
         //env 등을 통해서 외부 환경변수로부터 데이터를 받아올 수 있다
+        log.info("jwtSecretKey: {}", jwtSecretKey);
         this.jwtSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(jwtSecretKey));
         this.jwtExpirationInMs = 1000L * 20; //20초
         this.refreshTokenExpirationInMs = 1000L * 60; //60초
@@ -43,7 +44,7 @@ public class JwtTokenProvider implements LoginAuthTokenPort {
                 .subject(membershipId.getMembershipId())
                 .issuedAt(now)
                 .expiration(expiryDate)
-                .signWith(jwtSecretKey, Jwts.SIG.HS512)
+                .signWith(jwtSecretKey)
                 .compact();
     }
 


### PR DESCRIPTION
- requestMapping에 gateway 통합 url 매핑을 위한 api/v1 추가
- 로그아웃 controller 구조 작성
- 회원 권한 부여를 위해 entity에 role 추가
- 회원가입, 로그인시 캐싱 패턴 적용을 위한 로컬캐시 사용

closed #129